### PR TITLE
Drag and drop (#69)

### DIFF
--- a/frontend/dialob-composer-material/package.json
+++ b/frontend/dialob-composer-material/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@atlaskit/tree": "^8.8.7",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.19",

--- a/frontend/dialob-composer-material/src/App.tsx
+++ b/frontend/dialob-composer-material/src/App.tsx
@@ -1,15 +1,10 @@
-import { Container, Typography } from '@mui/material'
 import { ComposerProvider } from './dialob'
-import { DebugFormView } from './views/DebugFormView';
-
-// TODO: Use built-in test form here
 import testForm from './dialob/test/testForm.json';
 import ComposerLayoutView from './views/layout/ComposerLayoutView';
 import { IntlProvider } from 'react-intl';
 import messages from './intl';
 
 function App() {
-
   return (
     <ComposerProvider formData={testForm}>
       <IntlProvider locale='en' messages={messages['en']}>
@@ -19,4 +14,4 @@ function App() {
   )
 }
 
-export default App
+export default App;

--- a/frontend/dialob-composer-material/src/App.tsx
+++ b/frontend/dialob-composer-material/src/App.tsx
@@ -4,15 +4,17 @@ import { DebugFormView } from './views/DebugFormView';
 
 // TODO: Use built-in test form here
 import testForm from './dialob/test/testForm.json';
+import ComposerLayoutView from './views/layout/ComposerLayoutView';
+import { IntlProvider } from 'react-intl';
+import messages from './intl';
 
 function App() {
- 
+
   return (
     <ComposerProvider formData={testForm}>
-      <Container>
-        <Typography variant='h4'>Dialob Composer</Typography>
-        <DebugFormView />
-      </Container>
+      <IntlProvider locale='en' messages={messages['en']}>
+        <ComposerLayoutView />
+      </IntlProvider>
     </ComposerProvider>
   )
 }

--- a/frontend/dialob-composer-material/src/defaults/IconConfig.ts
+++ b/frontend/dialob-composer-material/src/defaults/IconConfig.ts
@@ -1,0 +1,25 @@
+import { SvgIconProps } from "@mui/material";
+import { 
+  BlurLinear, CalendarMonth, CheckBox, CropSquare, Euro, FolderOpen, 
+  KeyboardArrowDown, List, MoreHoriz, Note, Place, Schedule, 
+  TableRows, Tag, TextFormat 
+} from "@mui/icons-material";
+
+
+export const DEFAULT_ICON_CONFIG: Record<string, React.ComponentType<SvgIconProps>> = {
+  group: CropSquare,
+  surveygroup: BlurLinear,
+  rowgroup: TableRows,
+  survey: MoreHoriz,
+  address: Place,
+  text: TextFormat,
+  time: Schedule,
+  date: CalendarMonth,
+  number: Tag,
+  decimal: Euro,
+  boolean: CheckBox,
+  list: KeyboardArrowDown,
+  multichoice: List,
+  note: Note,
+  page: FolderOpen,
+}

--- a/frontend/dialob-composer-material/src/intl/en.ts
+++ b/frontend/dialob-composer-material/src/intl/en.ts
@@ -1,0 +1,15 @@
+const en = {
+  'locales.english': 'English',
+
+  'translations': 'Translations',
+  'variables': 'Variables',
+  'lists': 'Lists',
+  'options': 'Options',
+  'version': 'Version',
+  'version.latest': 'LATEST',
+  'search': 'Search',
+  'preview': 'Preview',
+
+};
+
+export default en;

--- a/frontend/dialob-composer-material/src/intl/index.ts
+++ b/frontend/dialob-composer-material/src/intl/index.ts
@@ -1,0 +1,7 @@
+import en from './en';
+
+const result: {[key: string]: any}  = {
+  en: en,
+};
+
+export default result;

--- a/frontend/dialob-composer-material/src/theme/siteTheme.ts
+++ b/frontend/dialob-composer-material/src/theme/siteTheme.ts
@@ -288,6 +288,26 @@ const siteTheme = createTheme({
         }
       },
     },
+
+    MuiStack: {
+      styleOverrides: {
+        root: {
+          height: 50,
+        }
+      }
+    },
+
+    MuiDrawer: {
+      styleOverrides: {
+        root: {
+          width: 240,
+        },
+        paper: {
+          width: 240,
+        },
+      }
+    },
+
   },
 
 });

--- a/frontend/dialob-composer-material/src/theme/siteTheme.ts
+++ b/frontend/dialob-composer-material/src/theme/siteTheme.ts
@@ -300,10 +300,10 @@ const siteTheme = createTheme({
     MuiDrawer: {
       styleOverrides: {
         root: {
-          width: 240,
+          width: 300,
         },
         paper: {
-          width: 240,
+          width: 300,
         },
       }
     },

--- a/frontend/dialob-composer-material/src/views/DebugFormView.tsx
+++ b/frontend/dialob-composer-material/src/views/DebugFormView.tsx
@@ -1,24 +1,48 @@
 import { Box, Button, Typography } from "@mui/material";
 import { useComposer } from "../dialob";
+import { buildTreeFromForm } from "./tree/TreeBuilder";
+import { TreeItem } from "@atlaskit/tree";
 
-// Debug view listing all item ID-s in the given form state
-export const DebugFormView: React.FC = () => {
- const { form, addItem } = useComposer();
 
- function onNewItemClick() {
-    addItem({id: '', type: 'text', view: 'debug', label: { en: 'Test'}}, 'group15');
- }
+const DebugFormView: React.FC = () => {
+  const { form, addItem } = useComposer();
+  const tree = Object.values(buildTreeFromForm(form.data).items).filter(item => item.id != 'root');
 
- return (
-  <>
-  <Box>
-    <Button onClick={onNewItemClick}>Add</Button>
-  </Box>
-   <Box>
-      {
-        Object.keys(form.data).map(itemId => <Typography key={itemId}>{itemId}</Typography>)
-      }
-   </Box> 
-   </>
- );
+  function onNewItemClick() {
+    addItem({ id: '', type: 'text', view: 'debug', label: { en: 'Test' } }, 'group15');
+  }
+
+  const calculateDepth = (node: TreeItem, parentDepth: number = 0): number => {
+    if (node.children.length === 0) {
+      return parentDepth;
+    }
+
+    const childDepths = node.children.map((childId) => {
+      const childNode = tree.find((item) => item.id === childId);
+      return childNode ? calculateDepth(childNode, parentDepth + 1) : parentDepth + 1;
+    });
+
+    return Math.max(...childDepths);
+  };
+
+  return (
+    <Box sx={{ ml: 10 }}>
+      <Box>
+        <Button onClick={onNewItemClick}>Add</Button>
+      </Box>
+      <Box>
+        {
+          tree.map(item => {
+            const depth = calculateDepth(item);
+            const childSx = { ml: depth * -2 };
+            return (
+              <Typography sx={childSx} key={item.id}>{item.id}</Typography>
+            );
+          })
+        }
+      </Box>
+    </Box>
+  );
 }
+
+export default DebugFormView;

--- a/frontend/dialob-composer-material/src/views/layout/ComposerLayoutView.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/ComposerLayoutView.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Drawer, Box, useTheme, CSSObject, Container } from '@mui/material';
+import MenuBar from './MenuBar';
+import NavigationPane from './NavigationPane';
+import EditorArea from './EditorArea';
+import ErrorPane from './ErrorPane';
+
+const ComposerLayoutView: React.FC = () => {
+  const theme = useTheme();
+  const menuHeight = (theme.components?.MuiStack?.styleOverrides?.root as CSSObject)?.height;
+
+  return (
+    <Box display='flex'>
+      <MenuBar />
+      <Drawer variant="permanent">
+        <Box sx={{ mt: `${menuHeight}px` }}>
+          <NavigationPane />
+        </Box>
+      </Drawer>
+      <Container>
+        <Box sx={{ mt: `${menuHeight}px` }}>
+          <EditorArea />
+        </Box>
+      </Container>
+      <Drawer variant="permanent" anchor="right">
+        <Box sx={{ mt: `${menuHeight}px` }}>
+          <ErrorPane />
+        </Box>
+      </Drawer>
+    </Box>
+  );
+};
+
+export default ComposerLayoutView;

--- a/frontend/dialob-composer-material/src/views/layout/EditorArea.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/EditorArea.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import DebugFormView from '../DebugFormView';
+import { Box } from '@mui/material';
 
 const EditorArea: React.FC = () => {
   return (
-    <>
-      Editor Area
-    </>
+    <Box sx={{ pt: 2 }}>
+      <DebugFormView />
+    </Box>
   );
 };
 

--- a/frontend/dialob-composer-material/src/views/layout/EditorArea.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/EditorArea.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const EditorArea: React.FC = () => {
+  return (
+    <>
+      Editor Area
+    </>
+  );
+};
+
+export default EditorArea;

--- a/frontend/dialob-composer-material/src/views/layout/ErrorPane.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/ErrorPane.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ErrorPane: React.FC = () => {
+  return (
+    <>
+      Error Pane
+    </>
+  );
+};
+
+export default ErrorPane;

--- a/frontend/dialob-composer-material/src/views/layout/MenuBar.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/MenuBar.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { AppBar, Box, Divider, InputBase, Stack, Typography, useTheme, Button } from '@mui/material';
+import { ArrowDropDown, Check, Close, Download, Search, Support, Visibility } from '@mui/icons-material';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useComposer } from '../../dialob';
+
+
+const HeaderButton: React.FC<{
+  label: string, startIcon?: React.ReactElement,
+  endIcon?: React.ReactElement
+}> = ({ label, startIcon, endIcon }) => {
+  return (
+    <Button variant='text' color='inherit' sx={{ px: 1 }} startIcon={startIcon} endIcon={endIcon}>
+      <FormattedMessage id={label} />
+    </Button>
+  );
+};
+
+const HeaderIconButton: React.FC<{ icon: React.ReactElement }> = ({ icon }) => {
+  return (
+    <Button variant='text' color='inherit' sx={{ px: 1 }}>
+      {icon}
+    </Button>
+  );
+};
+
+const MenuBar: React.FC = () => {
+  const theme = useTheme();
+  const intl = useIntl();
+  const { form } = useComposer();
+  const headerPaddingSx = { px: theme.spacing(1) };
+
+  return (
+    <AppBar position="fixed" color='inherit' sx={{ zIndex: theme.zIndex.drawer + 1 }}>
+      <Stack direction='row' divider={<Divider orientation='vertical' flexItem />}>
+        <Box sx={{ display: 'flex', alignItems: 'center', ...headerPaddingSx }}>
+          <Typography sx={{ fontWeight: 'bold' }}>
+            Dialob Composer
+          </Typography>
+          <Typography sx={{ ml: 1 }}>
+            {form.metadata.label}
+          </Typography>
+        </Box>
+        <HeaderButton label='translations' />
+        <HeaderButton label='variables' />
+        <HeaderButton label='lists' />
+        <HeaderButton label='options' />
+        <HeaderButton label={intl.formatMessage({ id: 'version' }) + ": " + intl.formatMessage({ id: 'latest' })} endIcon={<ArrowDropDown />} />
+        <HeaderIconButton icon={<Support fontSize='small' />} />
+        <Box flexGrow={1} />
+        <Box sx={{ display: 'flex', alignItems: 'center', ...headerPaddingSx }}>
+          <InputBase placeholder={intl.formatMessage({ id: 'search' })} />
+          <Search />
+        </Box>
+        <HeaderIconButton icon={<Download />} />
+        <HeaderIconButton icon={<Check color='success' />} />
+        <HeaderButton label='locales.english' endIcon={<ArrowDropDown />} />
+        <HeaderIconButton icon={<Visibility fontSize='small' />} />
+        <HeaderIconButton icon={<Close />} />
+      </Stack>
+    </AppBar>
+  );
+};
+
+export default MenuBar;

--- a/frontend/dialob-composer-material/src/views/layout/NavigationPane.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/NavigationPane.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import NavigationTreeView from '../tree/NavigationTreeView';
 
 const NavigationPane: React.FC = () => {
   return (
     <>
-      Navigation Pane
+      <NavigationTreeView />
     </>
   );
 };

--- a/frontend/dialob-composer-material/src/views/layout/NavigationPane.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/NavigationPane.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const NavigationPane: React.FC = () => {
+  return (
+    <>
+      Navigation Pane
+    </>
+  );
+};
+
+export default NavigationPane;

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
@@ -51,7 +51,7 @@ const NavigationTreeItem: React.FC<TreeItemProps> = ({ item, onExpand, onCollaps
     >
       {getIcon(item, onExpand, onCollapse)}
       {getTypeIcon(item.data.type)}
-      <ListItemText sx={{ cursor: 'pointer' }} onClick={() => { console.log('navigate to item', item.id) }}>{item.data ? item.data.title : ''}</ListItemText>
+      <ListItemText sx={{ cursor: 'pointer' }}>{item.data ? item.data.title : ''}</ListItemText>
     </ListItem>
   );
 };

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { ListItem, ListItemText, styled } from '@mui/material';
+import { TreeItem, ItemId } from '@atlaskit/tree';
+import { ArrowDropDown, ArrowRight } from '@mui/icons-material';
+import { DEFAULT_ICON_CONFIG } from '../../defaults/IconConfig';
+import { TreeDraggableProvided } from '@atlaskit/tree/dist/types/components/TreeItem/TreeItem-types';
+
+
+interface TreeItemProps {
+  item: TreeItem;
+  onExpand: (itemId: ItemId) => void;
+  onCollapse: (itemId: ItemId) => void;
+  provided: TreeDraggableProvided;
+}
+
+const PreTextIcon = styled('span')({
+  width: '24px',
+  cursor: 'pointer',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
+});
+
+const getIcon = (
+  item: TreeItem,
+  onExpand: (itemId: ItemId) => void,
+  onCollapse: (itemId: ItemId) => void,
+) => {
+  if (item.children && item.children.length > 0) {
+    return item.isExpanded ? (
+      <PreTextIcon onClick={() => onCollapse(item.id)}><ArrowDropDown fontSize='small' /></PreTextIcon>
+    ) : (
+      <PreTextIcon onClick={() => onExpand(item.id)}><ArrowRight fontSize='small' /></PreTextIcon>
+    );
+  }
+  return <PreTextIcon />;
+};
+
+const getTypeIcon = (type: string) => {
+  const Icon = DEFAULT_ICON_CONFIG[type];
+  return <PreTextIcon><Icon fontSize='small' /></PreTextIcon>;
+}
+
+
+const NavigationTreeItem: React.FC<TreeItemProps> = ({ item, onExpand, onCollapse, provided }) => {
+  return (
+    <ListItem
+      ref={provided.innerRef}
+      {...provided.draggableProps}
+      {...provided.dragHandleProps}
+    >
+      {getIcon(item, onExpand, onCollapse)}
+      {getTypeIcon(item.data.type)}
+      <ListItemText sx={{ cursor: 'pointer' }} onClick={() => { console.log('navigate to item', item.id) }}>{item.data ? item.data.title : ''}</ListItemText>
+    </ListItem>
+  );
+};
+
+export default NavigationTreeItem;

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
@@ -14,7 +14,7 @@ interface TreeItemProps {
 }
 
 const PreTextIcon = styled('span')({
-  width: '24px',
+  width: '1.5em',
   cursor: 'pointer',
   display: 'flex',
   alignItems: 'center',

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { Box, useTheme } from '@mui/material';
+import Tree, {
+  mutateTree,
+  moveItemOnTree,
+  TreeData,
+  ItemId,
+  TreeSourcePosition,
+  TreeDestinationPosition,
+  RenderItemParams,
+} from '@atlaskit/tree';
+import { useComposer } from '../../dialob';
+import { buildTreeFromForm } from './TreeBuilder';
+import NavigationTreeItem from './NavigationTreeItem';
+
+
+const isParentNode = (tree: TreeData, destination?: TreeDestinationPosition): boolean => {
+  if (!destination) {
+    return false;
+  }
+  if (destination.parentId.toString().includes('root')) {
+    return true;
+  }
+  const destinationItem = tree.items[destination.parentId];
+  if (destinationItem.data.type === 'group' || destinationItem.data.type === 'surveygroup' || destinationItem.data.type === 'rowgroup') {
+    return true;
+  }
+  return false;
+}
+
+const renderItem = ({ item, onExpand, onCollapse, provided }: RenderItemParams) => {
+  return (
+    <NavigationTreeItem item={item} onExpand={onExpand} onCollapse={onCollapse} provided={provided} />
+  );
+}
+
+const NavigationTreeView: React.FC = () => {
+  const theme = useTheme();
+  const { form, moveItem } = useComposer();
+  const treeData: TreeData = buildTreeFromForm(form.data);
+  const [tree, setTree] = useState<TreeData>(treeData);
+
+  React.useEffect(() => {
+    setTree(buildTreeFromForm(form.data));
+
+  }, [form]);
+
+  console.log('treeData', treeData)
+  console.log('formData', form.data)
+
+  const onExpand = (itemId: ItemId) => {
+    setTree((prevTree) => mutateTree(prevTree, itemId, { isExpanded: true }));
+  };
+
+  const onCollapse = (itemId: ItemId) => {
+    setTree((prevTree) => mutateTree(prevTree, itemId, { isExpanded: false }));
+  };
+
+  const onDragEnd = (
+    source: TreeSourcePosition,
+    destination?: TreeDestinationPosition,
+  ) => {
+    console.log('source', source)
+    console.log('destination', destination)
+    console.log('tree', tree)
+
+    if (!destination) {
+      return;
+    }
+    if (!isParentNode(tree, destination)) {
+      return;
+    }
+    const newTree = moveItemOnTree(tree, source, destination);
+    setTree(newTree);
+
+    console.log('newTree', newTree)
+
+    const item = newTree.items[destination.parentId].children[destination.index!];
+    moveItem(item.toString(), source.index, destination.index!, source.parentId.toString(), destination.parentId.toString());
+    console.log('new state', form.data)
+  };
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Tree
+        tree={tree}
+        renderItem={renderItem}
+        onExpand={onExpand}
+        onCollapse={onCollapse}
+        onDragEnd={onDragEnd}
+        offsetPerLevel={Number.parseInt(theme.spacing(2))}
+        isDragEnabled
+        isNestingEnabled
+      />
+    </Box>
+  );
+};
+
+export default NavigationTreeView;

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
@@ -14,6 +14,11 @@ import { buildTreeFromForm } from './TreeBuilder';
 import NavigationTreeItem from './NavigationTreeItem';
 
 
+const INIT_TREE: TreeData = {
+  rootId: 'root',
+  items: {},
+};
+
 const isParentNode = (tree: TreeData, destination?: TreeDestinationPosition): boolean => {
   if (!destination) {
     return false;
@@ -46,12 +51,10 @@ const renderItem = ({ item, onExpand, onCollapse, provided }: RenderItemParams) 
 const NavigationTreeView: React.FC = () => {
   const theme = useTheme();
   const { form, moveItem } = useComposer();
-  const treeData: TreeData = buildTreeFromForm(form.data);
-  const [tree, setTree] = useState<TreeData>(treeData);
+  const [tree, setTree] = useState<TreeData>(INIT_TREE);
 
   React.useEffect(() => {
     setTree(buildTreeFromForm(form.data));
-
   }, [form]);
 
   const onExpand = (itemId: ItemId) => {

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
@@ -28,6 +28,15 @@ const isParentNode = (tree: TreeData, destination?: TreeDestinationPosition): bo
   return false;
 }
 
+const isEmptyParentNode = (tree: TreeData, destination?: TreeDestinationPosition): boolean => {
+  const isParent = isParentNode(tree, destination);
+  if (!isParent) {
+    return false;
+  }
+  const destinationItem = tree.items[destination!.parentId];
+  return destinationItem.children.length === 0;
+}
+
 const renderItem = ({ item, onExpand, onCollapse, provided }: RenderItemParams) => {
   return (
     <NavigationTreeItem item={item} onExpand={onExpand} onCollapse={onCollapse} provided={provided} />
@@ -70,9 +79,10 @@ const NavigationTreeView: React.FC = () => {
     if (!isParentNode(tree, destination)) {
       return;
     }
+    if (isEmptyParentNode(tree, destination)) {
+      destination.index = 0;
+    }
     const newTree = moveItemOnTree(tree, source, destination);
-    setTree(newTree);
-
     console.log('newTree', newTree)
 
     const item = newTree.items[destination.parentId].children[destination.index!];

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
@@ -54,9 +54,6 @@ const NavigationTreeView: React.FC = () => {
 
   }, [form]);
 
-  console.log('treeData', treeData)
-  console.log('formData', form.data)
-
   const onExpand = (itemId: ItemId) => {
     setTree((prevTree) => mutateTree(prevTree, itemId, { isExpanded: true }));
   };
@@ -69,10 +66,6 @@ const NavigationTreeView: React.FC = () => {
     source: TreeSourcePosition,
     destination?: TreeDestinationPosition,
   ) => {
-    console.log('source', source)
-    console.log('destination', destination)
-    console.log('tree', tree)
-
     if (!destination) {
       return;
     }
@@ -83,11 +76,8 @@ const NavigationTreeView: React.FC = () => {
       destination.index = 0;
     }
     const newTree = moveItemOnTree(tree, source, destination);
-    console.log('newTree', newTree)
-
     const item = newTree.items[destination.parentId].children[destination.index!];
     moveItem(item.toString(), source.index, destination.index!, source.parentId.toString(), destination.parentId.toString());
-    console.log('new state', form.data)
   };
 
   return (

--- a/frontend/dialob-composer-material/src/views/tree/TreeBuilder.ts
+++ b/frontend/dialob-composer-material/src/views/tree/TreeBuilder.ts
@@ -1,0 +1,56 @@
+import { ItemId, TreeData } from "@atlaskit/tree";
+import { DialobItem } from "../../dialob";
+
+
+export const buildTreeFromForm = (formData: { [item: string]: DialobItem }): TreeData => {
+  const tree: TreeData = {
+    rootId: 'root',
+    items: {
+      root: {
+        id: 'root',
+        children: [],
+        data: {
+          title: 'root',
+        },
+      },
+    },
+  };
+
+  const addChildrenFromParent = (item: DialobItem, parentId: ItemId) => {
+    if (item.items) {
+      const childItems = Object.values(formData)
+        .filter(child => item.items?.includes(child.id))
+        .sort((a, b) => item.items!.indexOf(a.id) - item.items!.indexOf(b.id));
+      childItems.forEach(child => {
+        addChild(child, parentId);
+        addChildrenFromParent(child, child.id);
+      });
+    }
+  }
+
+  const addChild = (item: DialobItem, parentId: ItemId) => {
+    const id = item.id;
+    const type = item.type === 'group' && parentId === 'root' ? 'page' : item.type;
+    tree.items[id] = {
+      id,
+      children: [],
+      data: {
+        title: id,
+        type
+      },
+      isExpanded: true,
+      hasChildren: item.items?.length ? true : false,
+    };
+    tree.items[parentId].children.push(id);
+  };
+
+  const formRoot = Object.values(formData).find(item => item.type === 'questionnaire');
+
+  if (!formRoot) {
+    return tree;
+  }
+  addChildrenFromParent(formRoot, 'root');
+
+  return tree;
+
+}

--- a/frontend/dialob-composer-material/yarn.lock
+++ b/frontend/dialob-composer-material/yarn.lock
@@ -15,6 +15,15 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@atlaskit/tree@^8.8.7":
+  version "8.8.7"
+  resolved "https://registry.npmjs.org/@atlaskit/tree/-/tree-8.8.7.tgz#f895137b063f676a490abb0b5deb939a96f51fd7"
+  integrity sha512-ftbFCzZoa5tZh35EdwMEP9lPuBfw19vtB1CcBmDDMP0AnyEXLjUVfVo8kIls6oI4wivYfIWkZgrUlgN+Jk1b0Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    css-box-model "^1.2.0"
+    react-beautiful-dnd-next "11.0.5"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.23.5":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
@@ -276,6 +285,21 @@
   integrity sha512-91RS0MDnAWDNvGC6Wio5XYkyWI39FMFO+JK9+4AlgaTH+yWwVTsw7/sn6LK0lH7c5F+TFkpv/3LfCJ1Ydwof/g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
+
+"@babel/runtime-corejs2@^7.4.5":
+  version "7.23.6"
+  resolved "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.23.6.tgz#00d4a77e49a33540160312ecb329ac1ba73df3f9"
+  integrity sha512-k8QKC2DmBqkwJDOLa4biAZjoCGPQIaAoA1HvHtZ+gR2E9AauudikJOB34h4ETEavN5UG21X0KPdM3IvBRxM0CA==
+  dependencies:
+    core-js "^2.6.12"
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.15.4", "@babel/runtime@^7.9.2":
+  version "7.23.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz#c05e610dc228855dc92ef1b53d07389ed8ab521d"
+  integrity sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.23.5"
@@ -1157,6 +1181,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.5"
+  resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
+  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -1224,6 +1256,16 @@
   integrity sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.32"
+  resolved "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.32.tgz#bf162289e0c69e44a649dfcadb30f7f7c4cb00e4"
+  integrity sha512-YJYV0M27cyHHJIacaRsZRx5OETzK8KWjEGnix7UH3ngItYo4It0MUBzU6WNwqnwhbrPw5wx9KXluuoTZ85Gg7A==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-transition-group@^4.4.9":
   version "4.4.10"
@@ -1717,6 +1759,11 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
+core-js@^2.6.12:
+  version "2.6.12"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
 cosmiconfig@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
@@ -1754,6 +1801,13 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-box-model@^1.1.2, css-box-model@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  dependencies:
+    tiny-invariant "^1.0.6"
 
 csstype@^3.0.2, csstype@^3.1.2:
   version "3.1.3"
@@ -2346,7 +2400,7 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -3150,6 +3204,11 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+memoize-one@^5.0.4:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3413,7 +3472,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -3437,6 +3496,25 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+raf-schd@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
+  integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
+react-beautiful-dnd-next@11.0.5:
+  version "11.0.5"
+  resolved "https://registry.npmjs.org/react-beautiful-dnd-next/-/react-beautiful-dnd-next-11.0.5.tgz#41e693733bbdeb6269b9e4b923a36de2e99ed761"
+  integrity sha512-kM5Mob41HkA3ShS9uXqeMkW51L5bVsfttxfrwwHucu7I6SdnRKCyN78t6QiLH/UJQQ8T4ukI6NeQAQQpGwolkg==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.5"
+    css-box-model "^1.1.2"
+    memoize-one "^5.0.4"
+    raf-schd "^4.0.0"
+    react-redux "^7.0.3"
+    redux "^4.0.1"
+    tiny-invariant "^1.0.4"
+    use-memo-one "^1.1.0"
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -3450,7 +3528,7 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^17.0.1:
+react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -3459,6 +3537,18 @@ react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-redux@^7.0.3:
+  version "7.2.9"
+  resolved "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz#09488fbb9416a4efe3735b7235055442b042481d"
+  integrity sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@^0.14.0:
   version "0.14.0"
@@ -3481,6 +3571,13 @@ react@^18.2.0:
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
+
+redux@^4.0.0, redux@^4.0.1:
+  version "4.2.1"
+  resolved "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
 
 regenerator-runtime@^0.14.0:
   version "0.14.0"
@@ -3770,6 +3867,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+tiny-invariant@^1.0.4, tiny-invariant@^1.0.6:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
+  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -3871,6 +3973,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-memo-one@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Demo:

https://github.com/dialob/dialob-parent/assets/80248680/ad7a314b-8872-49f5-89c2-cde844cf1b47


This implementation should nicely demonstrate how @atlaskit/tree could be used for drag and drop features in Dialob, based on an example of a navigation tree. The tree is on the right, and a list of components is rendered from the form state next to it, to verify if the state changes accordingly.

Details:
- Implementation done using [@atlaskit/tree](https://atlaskit.atlassian.com/packages/confluence/tree) which is built on top of [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd) (also a package by atlassian)
- The atlaskit package renders a tree based on the following data structures
```
export type ItemId = string | number;
export interface TreeData {
    rootId: ItemId;
    items: Record<ItemId, TreeItem>;
}
export type TreeItemData = any;
export type TreeItem = {
    id: ItemId;
    children: ItemId[];
    hasChildren?: boolean;
    isExpanded?: boolean;
    isChildrenLoading?: boolean;
    data?: TreeItemData;
};
```
- The `data` field can be any object so this structure can easily be expandable to contain any kind of data, like the id, name, label, and specifically in this case the type of the Dialob item which is used to determine which icon will be rendered in the navigation tree
- The Tree is required the following parameters
```
<Tree
        tree={tree}
        renderItem={renderItem}
        onExpand={onExpand}
        onCollapse={onCollapse}
        onDragEnd={onDragEnd}
        offsetPerLevel={Number.parseInt(theme.spacing(2))}
        isDragEnabled
        isNestingEnabled
      />
```
- The `renderItem` method is used to render a `TreeItem`, and in this case MUI `ListItem` is used, but it could be virtually any element - it gets passed callback methods to handle expanding and collapsing since the Tree has its own logic for that
- The `onDragEnd` method handles the end of a drag operation, and it gets source and destination as parameters, so that it is exactly known which are the source and destination parents and indexes, which perfectly fits with the `moveItem` reducer method - this also means that `fromIndex` and `fromParent` don't need to be removed from the method call
- `onDragEnd` can be customized to for example check if a node can be a parent node etc.
- `offsetPerLevel` configures padding indentation which can come from the theme so it is easily customizable
- `isDragEnabled` enables drag and drop features while `isNestingEnabled` extends the feature to include being able to drag nested items
- This implementation also provides accessibility features by being able to "drag and drop" items using a keyboard