### PR TITLE
Handling large forms and long texts

### DIFF
--- a/frontend/dialob-composer-material/src/components/PageTabs.tsx
+++ b/frontend/dialob-composer-material/src/components/PageTabs.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Menu, MenuItem, Button, IconButton, Box, Table, TableRow, TableBody, TableContainer, CircularProgress, Typography, Paper, TableCell } from '@mui/material';
+import { Menu, MenuItem, Button, IconButton, Box, Table, TableRow, TableBody, TableContainer, CircularProgress, Typography, Paper, TableCell, Grid } from '@mui/material';
 import { Add, Close, ContentCopy, Key, Menu as MenuIcon, Tune } from '@mui/icons-material';
 import { DialobItem, DialobItems, useComposer } from "../dialob";
 import { useEditor } from "../editor";
@@ -9,6 +9,7 @@ import { FormattedMessage } from "react-intl";
 
 
 const MAX_PAGE_NAME_LENGTH = 40;
+const MAX_PAGES_PER_ROW = 5;
 
 const getPageTabTitle = (item: DialobItem, language: string): string => {
   const rawLabel = item.label ? item.label[language] : null;
@@ -155,7 +156,13 @@ const PageTabs: React.FC<{ items: DialobItems }> = ({ items }) => {
   return (
     <Box sx={{ mb: 1 }}>
       <Box sx={{ display: 'flex' }}>
-        {pages}
+        <Grid container>
+          {pages && pages.map((page, index) => (
+            <Grid item key={index}>
+              {page}
+            </Grid>
+          ))}
+        </Grid>
         <Box sx={{ flexGrow: 1 }} />
         <IconButton sx={{ alignSelf: 'center' }} onClick={handleCreate}>
           <Add />

--- a/frontend/dialob-composer-material/src/utils/ErrorUtils.tsx
+++ b/frontend/dialob-composer-material/src/utils/ErrorUtils.tsx
@@ -4,6 +4,7 @@ import { EditorError, ErrorSeverity } from "../editor";
 import { DialobItem } from "../dialob";
 import { Check, Info, Warning } from "@mui/icons-material";
 import { useIntl } from "react-intl";
+import { PreTextIcon } from "../views/tree/NavigationTreeItem";
 
 export const ErrorType: React.FC<{ error: EditorError }> = ({ error }) => {
   const intl = useIntl();
@@ -83,13 +84,13 @@ export const getErrorIcon = (errors: EditorError[], item: DialobItem): React.Rea
   const itemErrorSeverity = getItemErrorSeverity(errors, item);
   switch (itemErrorSeverity) {
     case 'FATAL':
-      return <Warning color='error' fontSize='small' />;
+      return <PreTextIcon disableRipple><Warning color='error' fontSize='small' /></PreTextIcon>;
     case 'ERROR':
-      return <Warning color='error' fontSize='small' />;
+      return <PreTextIcon disableRipple><Warning color='error' fontSize='small' /></PreTextIcon>;
     case 'WARNING':
-      return <Warning color='warning' fontSize='small' />;
+      return <PreTextIcon disableRipple><Warning color='warning' fontSize='small' /></PreTextIcon>;
     case 'INFO':
-      return <Info color='info' fontSize='small' />;
+      return <PreTextIcon disableRipple><Info color='info' fontSize='small' /></PreTextIcon>;
     default:
       return undefined;
   }

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
@@ -19,9 +19,10 @@ interface TreeItemProps {
 
 const MAX_TREE_ITEM_TITLE_LENGTH = 40;
 
-const PreTextIcon = styled(IconButton)(({ theme }) => ({
+export const PreTextIcon = styled(IconButton)(({ theme }) => ({
   padding: theme.spacing(0.5),
   color: 'inherit',
+  cursor: 'default',
 }));
 
 const ArrowIcon = styled(IconButton)(({ theme }) => ({

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ListItem, ListItemText, Typography, styled } from '@mui/material';
+import { ListItem, ListItemText, Typography, IconButton, styled } from '@mui/material';
 import { ArrowDropDown, ArrowRight } from '@mui/icons-material';
 import { TreeItem, ItemId } from '@atlaskit/tree';
 import { TreeDraggableProvided } from '@atlaskit/tree/dist/types/components/TreeItem/TreeItem-types';
@@ -17,13 +17,18 @@ interface TreeItemProps {
   provided: TreeDraggableProvided;
 }
 
-const PreTextIcon = styled('span')({
-  width: '1.5em',
-  cursor: 'pointer',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center'
-});
+const MAX_TREE_ITEM_TITLE_LENGTH = 40;
+
+const PreTextIcon = styled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(0.5),
+  color: 'inherit',
+}));
+
+const ArrowIcon = styled(IconButton)(({ theme }) => ({
+  padding: 0,
+  marginLeft: theme.spacing(0.5),
+  color: 'inherit',
+}));
 
 const getIcon = (
   item: TreeItem,
@@ -32,21 +37,31 @@ const getIcon = (
 ) => {
   if (item.children && item.children.length > 0) {
     return item.isExpanded ? (
-      <PreTextIcon onClick={() => onCollapse(item.id)}><ArrowDropDown fontSize='small' /></PreTextIcon>
+      <ArrowIcon onClick={() => onCollapse(item.id)}><ArrowDropDown fontSize='small' /></ArrowIcon>
     ) : (
-      <PreTextIcon onClick={() => onExpand(item.id)}><ArrowRight fontSize='small' /></PreTextIcon>
+      <ArrowIcon onClick={() => onExpand(item.id)}><ArrowRight fontSize='small' /></ArrowIcon>
     );
   }
-  return <PreTextIcon />;
+  return <ArrowIcon sx={{ mr: 0.5 }} />;
 };
 
 const getTypeIcon = (item: DialobItem, isPage: boolean) => {
   if (isPage) {
-    return <PreTextIcon><PAGE_CONFIG.icon fontSize='small' /></PreTextIcon>;
+    return <PreTextIcon disableRipple><PAGE_CONFIG.icon fontSize='small' /></PreTextIcon>;
   }
   const itemConfig = DEFAULT_ITEM_CONFIG.items.find(c => c.matcher(item));
   const Icon = itemConfig?.props.icon || DEFAULT_ITEM_CONFIG.defaultIcon;
-  return <PreTextIcon><Icon fontSize='small' /></PreTextIcon>;
+  return <PreTextIcon disableRipple sx={{ mr: 0.5 }}><Icon fontSize='small' /></PreTextIcon>;
+}
+
+const getTitle = (item: TreeItem) => {
+  if (!item.data) {
+    return '';
+  }
+  const rawTitle = item.data.title;
+  return rawTitle.length > MAX_TREE_ITEM_TITLE_LENGTH
+    ? rawTitle.substring(0, MAX_TREE_ITEM_TITLE_LENGTH) + '…'
+    : rawTitle;
 }
 
 const NavigationTreeItem: React.FC<TreeItemProps> = ({ item, onExpand, onCollapse, provided }) => {
@@ -69,7 +84,7 @@ const NavigationTreeItem: React.FC<TreeItemProps> = ({ item, onExpand, onCollaps
       {getIcon(item, onExpand, onCollapse)}
       {errorColor ? getErrorIcon(editor.errors, item.data.item) : getTypeIcon(item.data.item, item.data.isPage)}
       <ListItemText sx={{ cursor: 'pointer', ':hover': { color: 'text.secondary' } }} onClick={handleScrollTo}>
-        <Typography sx={{ color: errorColor, ':hover': { color: 'text.secondary' } }}>{item.data ? item.data.title : ''}</Typography>
+        <Typography sx={{ color: errorColor, ':hover': { color: 'text.secondary' } }}>{getTitle(item)}</Typography>
       </ListItemText>
     </ListItem>
   );


### PR DESCRIPTION
Improvements for handling forms with many pages and long labels:
- improved spacing and alignment of tree item icons
- truncating tree item titles
- page tabs (buttons) are now rendered in a grid that can span into multiple rows

![image](https://github.com/dialob/dialob-parent/assets/80248680/aa0d5438-f8ac-4ebc-9f77-c8cf46f56246)

