### PR TITLE
Material composer improvements v1

### DIFF
--- a/frontend/dialob-composer-material/src/components/ChoiceEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceEditor.tsx
@@ -11,6 +11,7 @@ import { StyledTable } from './TableEditorComponents';
 import ChoiceList from './ChoiceList';
 import ConvertConfirmationDialog from '../dialogs/ConvertConfirmationDialog';
 import UploadValuesetDialog from '../dialogs/UploadValuesetDialog';
+import GlobalList from './GlobalList';
 
 
 const ChoiceEditor: React.FC = () => {
@@ -146,6 +147,7 @@ const ChoiceEditor: React.FC = () => {
             <FormattedMessage id='dialogs.options.choices.convert.local' />
           </Button>
         </Box>
+        <GlobalList entries={currentValueSet?.entries} />
         <Divider sx={{ my: 2 }}><Typography><FormattedMessage id='dialogs.options.choices.divider' /></Typography></Divider>
         <Button color='inherit' variant='contained' onClick={createLocalList}>
           <FormattedMessage id='dialogs.options.choices.create.local' />

--- a/frontend/dialob-composer-material/src/components/ChoiceList.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceList.tsx
@@ -110,7 +110,8 @@ const ChoiceList: React.FC<{
     if (!destination || !valueSet) {
       return;
     }
-    moveItemOnTree(tree, source, destination);
+    const newTree = moveItemOnTree(tree, source, destination);
+    setTree(newTree);
     moveValueSetEntry(valueSet.id, source.index, destination.index!);
   };
 

--- a/frontend/dialob-composer-material/src/components/GlobalList.tsx
+++ b/frontend/dialob-composer-material/src/components/GlobalList.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { ValueSetEntry } from '../dialob';
+import { Table, TableBody, TableRow, TableCell, TableHead, Typography } from '@mui/material';
+import { StyledTable } from './TableEditorComponents';
+import { FormattedMessage } from 'react-intl';
+import { useEditor } from '../editor';
+
+const GlobalList: React.FC<{ entries?: ValueSetEntry[] }> = ({ entries }) => {
+  const { editor } = useEditor();
+
+  if (!entries) {
+    return null;
+  }
+
+  return (
+    <StyledTable sx={{ mt: 2 }}>
+      <TableHead>
+        <TableRow>
+          <TableCell sx={{ p: 1 }}>
+            <Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography>
+          </TableCell>
+          <TableCell sx={{ p: 1 }}>
+            <Typography fontWeight='bold'><FormattedMessage id='dialogs.options.text' /></Typography>
+          </TableCell>
+          <TableCell sx={{ p: 1 }}>
+            <Typography fontWeight='bold'><FormattedMessage id='dialogs.options.rule' /></Typography>
+          </TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {entries.map((entry, idx) => (
+          <TableRow key={entry.id}>
+            <TableCell sx={{ p: 1 }}>
+              {entry.id}
+            </TableCell>
+            <TableCell sx={{ p: 1 }}>
+              {entry.label[editor.activeFormLanguage]}
+            </TableCell>
+            <TableCell sx={{ p: 1 }}>
+              {entry.when}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </StyledTable>
+  );
+}
+
+export default GlobalList;

--- a/frontend/dialob-composer-material/src/dialogs/TextEditDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/TextEditDialog.tsx
@@ -36,6 +36,7 @@ const TextEditDialog: React.FC = () => {
     } else {
       setLocalizedText('');
     }
+    setPreview(false);
   }, [activeLanguage, editor.textEditDialogType, item]);
 
   if (!item) {

--- a/frontend/dialob-composer-material/src/editor/actions.ts
+++ b/frontend/dialob-composer-material/src/editor/actions.ts
@@ -12,3 +12,4 @@ export type EditorAction =
   | { type: 'setRuleEditDialogType', dialogType?: RuleEditDialogType }
   | { type: 'setValidationRuleEditDialogOpen', open: boolean }
   | { type: 'setItemOptionsDialogOpen', open: boolean }
+  | { type: 'setHighlightedItem', item?: DialobItem };

--- a/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
+++ b/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
@@ -46,6 +46,10 @@ export const useEditor = () => {
     dispatch({ type: 'setItemOptionsDialogOpen', open });
   }
 
+  const setHighlightedItem = (item?: DialobItem): void => {
+    dispatch({ type: 'setHighlightedItem', item });
+  }
+
   return {
     editor: state,
     setActivePage,
@@ -58,5 +62,6 @@ export const useEditor = () => {
     setRuleEditDialogType,
     setValidationRuleEditDialogOpen,
     setItemOptionsDialogOpen,
+    setHighlightedItem,
   };
 }

--- a/frontend/dialob-composer-material/src/editor/reducer.ts
+++ b/frontend/dialob-composer-material/src/editor/reducer.ts
@@ -65,6 +65,8 @@ export const editorReducer = (state: EditorState, action: EditorAction): EditorS
       setValidationRuleEditDialogOpen(state, action.open);
     } else if (action.type === 'setItemOptionsDialogOpen') {
       setItemOptionsDialogOpen(state, action.open);
+    } else if (action.type === 'setHighlightedItem') {
+      state.highlightedItem = action.item;
     }
   });
   return newState;

--- a/frontend/dialob-composer-material/src/editor/types.ts
+++ b/frontend/dialob-composer-material/src/editor/types.ts
@@ -23,4 +23,5 @@ export type EditorState = {
   ruleEditDialogType?: RuleEditDialogType;
   validationRuleEditDialogOpen?: boolean;
   itemOptionsDialogOpen?: boolean;
+  highlightedItem?: DialobItem;
 };

--- a/frontend/dialob-composer-material/src/intl/en.ts
+++ b/frontend/dialob-composer-material/src/intl/en.ts
@@ -66,6 +66,7 @@ const en = {
   'dialogs.options.key': 'Key',
   'dialogs.options.value': 'Value',
   'dialogs.options.text': 'Text',
+  'dialogs.options.rule': 'Rule',
   'dialogs.options.choices.convert.local': 'Convert to local list',
   'dialogs.options.choices.convert.global': 'Convert to global list',
   'dialogs.options.choices.create.local': 'Create local list',

--- a/frontend/dialob-composer-material/src/items/Group.tsx
+++ b/frontend/dialob-composer-material/src/items/Group.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { KeyboardArrowDown, KeyboardArrowRight } from '@mui/icons-material';
-import { Box, IconButton, Paper, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
+import { Box, IconButton, Paper, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
 import { Element } from 'react-scroll';
 import { DialobItem, DialobItems, useComposer } from '../dialob';
 import { AddItemMenu, ConversionMenu, IdField, Indicators, LabelField, OptionsMenu, StyledTable, VisibilityField } from './ItemComponents';
@@ -16,6 +16,7 @@ const createChildren = (item: DialobItem, items: DialobItems) => {
 }
 
 const Group: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => {
+  const theme = useTheme();
   const { form } = useComposer();
   const { editor } = useEditor();
   const [expanded, setExpanded] = React.useState<boolean>(true);
@@ -23,10 +24,23 @@ const Group: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => 
   const centeredCellSx = { textAlign: 'center' };
   const errorBorderColor = useErrorColor(editor.errors, item);
   const hasIndicators = item.description || item.valueSetId || item.validations;
+  const [highlighted, setHighlighted] = React.useState<boolean>(false);
+  const highlightedSx = highlighted ?
+    { border: 1, borderColor: 'mainContent.contrastText', backgroundColor: alpha(theme.palette.mainContent.contrastText, 0.1) } : {};
+
+  React.useEffect(() => {
+    if (editor?.highlightedItem?.id === item.id) {
+      setHighlighted(true);
+    }
+    const id = setTimeout(() => {
+      setHighlighted(false);
+    }, 3000);
+    return () => clearTimeout(id);
+  }, [editor.highlightedItem])
 
   return (
     <Element name={item.id}>
-      <TableContainer component={Paper} sx={{ my: 2, }}>
+      <TableContainer component={Paper} sx={{ my: 2, ...highlightedSx }}>
         <StyledTable errorBorderColor={errorBorderColor}>
           <TableBody>
             <TableRow>

--- a/frontend/dialob-composer-material/src/items/Note.tsx
+++ b/frontend/dialob-composer-material/src/items/Note.tsx
@@ -1,16 +1,32 @@
 import React from 'react';
-import { Paper, Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
+import { Paper, Table, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
 import { Element } from 'react-scroll';
 import { DialobItem } from '../dialob';
 import { IdField, Indicators, NoteField, OptionsMenu } from './ItemComponents';
+import { useEditor } from '../editor';
 
 const Note: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => {
+  const theme = useTheme();
+  const { editor } = useEditor();
   const centeredCellSx = { textAlign: 'center' };
   const hasIndicators = item.description || item.valueSetId || item.validations;
+  const [highlighted, setHighlighted] = React.useState<boolean>(false);
+  const highlightedSx = highlighted ?
+    { border: 1, borderColor: 'mainContent.contrastText', backgroundColor: alpha(theme.palette.mainContent.contrastText, 0.1) } : {};
+
+  React.useEffect(() => {
+    if (editor?.highlightedItem?.id === item.id) {
+      setHighlighted(true);
+    }
+    const id = setTimeout(() => {
+      setHighlighted(false);
+    }, 3000);
+    return () => clearTimeout(id);
+  }, [editor.highlightedItem])
 
   return (
     <Element name={item.id}>
-      <TableContainer component={Paper} sx={{ my: 2 }}>
+      <TableContainer component={Paper} sx={{ my: 2, ...highlightedSx }}>
         <Table>
           <TableBody>
             <TableRow>

--- a/frontend/dialob-composer-material/src/items/SimpleField.tsx
+++ b/frontend/dialob-composer-material/src/items/SimpleField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Paper, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
+import { Paper, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
 import { Element } from 'react-scroll';
 import { DialobItem } from '../dialob';
 import { ConversionMenu, IdField, LabelField, Indicators, OptionsMenu, VisibilityField, StyledTable } from './ItemComponents';
@@ -8,14 +8,28 @@ import { useErrorColor } from '../utils/ErrorUtils';
 
 
 const SimpleField: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => {
+  const theme = useTheme();
   const { editor } = useEditor();
   const centeredCellSx = { textAlign: 'center' };
   const errorBorderColor = useErrorColor(editor.errors, item);
   const hasIndicators = item.description || item.valueSetId || item.validations;
+  const [highlighted, setHighlighted] = React.useState<boolean>(false);
+  const highlightedSx = highlighted ?
+    { border: 1, borderColor: 'mainContent.contrastText', backgroundColor: alpha(theme.palette.mainContent.contrastText, 0.1) } : {};
+
+  React.useEffect(() => {
+    if (editor?.highlightedItem?.id === item.id) {
+      setHighlighted(true);
+    }
+    const id = setTimeout(() => {
+      setHighlighted(false);
+    }, 3000);
+    return () => clearTimeout(id);
+  }, [editor.highlightedItem])
 
   return (
     <Element name={item.id}>
-      <TableContainer component={Paper} sx={{ my: 2 }}>
+      <TableContainer component={Paper} sx={{ my: 2, ...highlightedSx }}>
         <StyledTable errorBorderColor={errorBorderColor}>
           <TableBody>
             <TableRow>

--- a/frontend/dialob-composer-material/src/utils/ScrollUtils.tsx
+++ b/frontend/dialob-composer-material/src/utils/ScrollUtils.tsx
@@ -33,8 +33,9 @@ export const scrollToItem = (itemId: string, items: DialobItem[], activePage: Di
       setActivePage(parent);
     }
   }
+  const viewportOffset = window.innerHeight - MENU_HEIGHT;
   setTimeout(() => scroller.scrollTo(itemId, {
-    offset: -MENU_HEIGHT - 10,
+    offset: -(viewportOffset / 2),
     duration: 500,
     smooth: true,
   }), timeout);

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
@@ -66,13 +66,14 @@ const getTitle = (item: TreeItem) => {
 }
 
 const NavigationTreeItem: React.FC<TreeItemProps> = ({ item, onExpand, onCollapse, provided }) => {
-  const { editor, setActivePage } = useEditor();
+  const { editor, setActivePage, setHighlightedItem } = useEditor();
   const { form } = useComposer();
   const errorColor = useErrorColor(editor.errors, item.data.item);
   const itemId = item.data.item.id;
 
   const handleScrollTo = (e: React.MouseEvent) => {
     e.stopPropagation();
+    setHighlightedItem(item.data.item);
     scrollToItem(itemId, Object.values(form.data), editor.activePage, setActivePage);
   }
 

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
@@ -85,6 +85,7 @@ const NavigationTreeView: React.FC = () => {
       destination.index = 0;
     }
     const newTree = moveItemOnTree(tree, source, destination);
+    setTree(newTree);
     const item = newTree.items[destination.parentId].children[destination.index!];
     moveItem(item.toString(), source.index, destination.index!, source.parentId.toString(), destination.parentId.toString());
   };


### PR DESCRIPTION
- read-only global list preview added to choice editor
![image](https://github.com/dialob/dialob-parent/assets/80248680/baac196d-4a67-4504-8c9b-57087a1f2b0d)

- scroll to item feature now also highlights the item after it's been scrolled to
![image](https://github.com/dialob/dialob-parent/assets/80248680/ac80ce0f-d725-423d-b142-1f07a50ad928)
