### PR TITLE
Global list edit dialog

### DIFF
--- a/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
@@ -17,6 +17,7 @@ export interface ChoiceItemProps {
   onTextEdit: (entry: ValueSetEntry, label: LocalizedString) => void,
   onDelete: (entry: ValueSetEntry) => void,
   onUpdateId: (entry: ValueSetEntry, id: string) => void,
+  isGlobal?: boolean
 }
 
 const MAX_CHOICE_LABEL_LENGTH = 40;
@@ -32,7 +33,7 @@ const getLabel = (entry: ValueSetEntry, language: string) => {
   return <Typography>{localizedLabel}</Typography>;
 }
 
-const ChoiceItem: React.FC<ChoiceItemProps> = ({ item, provided, onRuleEdit, onTextEdit, onDelete, onUpdateId }) => {
+const ChoiceItem: React.FC<ChoiceItemProps> = ({ item, provided, onRuleEdit, onTextEdit, onDelete, onUpdateId, isGlobal }) => {
   const { form } = useComposer();
   const entry = item.data;
   const formLanguages = form.metadata.languages;
@@ -70,7 +71,7 @@ const ChoiceItem: React.FC<ChoiceItemProps> = ({ item, provided, onRuleEdit, onT
             <TableCell align='center' width='20%'>
               <IconButton onClick={() => setExpanded(!expanded)}>{expanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}</IconButton>
               <IconButton onClick={() => setOpen(true)}><Close color='error' /></IconButton>
-              <IconButton onClick={() => setExpanded(true)}><Visibility color={entry.when ? 'primary' : 'inherit'} /></IconButton>
+              {!isGlobal && <IconButton onClick={() => setExpanded(true)}><Visibility color={entry.when ? 'primary' : 'inherit'} /></IconButton>}
             </TableCell>
             <TableCell width='30%' sx={{ p: 1 }}>
               <Typography>{idValue}</Typography>
@@ -88,11 +89,13 @@ const ChoiceItem: React.FC<ChoiceItemProps> = ({ item, provided, onRuleEdit, onT
                   <Typography color='text.hint' variant='caption'>Key</Typography>
                   <TextField value={idValue} onChange={(e) => setIdValue(e.target.value)} />
                 </Box>
-                <Box sx={{ display: 'flex', flexDirection: 'column', my: 1 }}>
+                {!isGlobal && <Box sx={{ display: 'flex', flexDirection: 'column', mt: 1 }}>
                   <Typography color='text.hint' variant='caption'>Visbility rule</Typography>
                   <CodeMirror value={rule || ''} onChange={(value) => setRule(value)} extensions={[javascript({ jsx: true })]} />
+                </Box>}
+                <Box sx={{ mt: 2 }}>
+                  <ChoiceTextEditor entry={entry} onUpdate={onTextEdit} />
                 </Box>
-                <ChoiceTextEditor entry={entry} onUpdate={onTextEdit} />
               </Box>
             </TableCell>
           </TableRow>}

--- a/frontend/dialob-composer-material/src/components/ChoiceList.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceList.tsx
@@ -11,10 +11,10 @@ const INIT_TREE: TreeData = {
 };
 
 const renderItem = (props: ChoiceItemProps) => {
-  const { item, provided, onRuleEdit, onTextEdit, onDelete, onUpdateId } = props;
+  const { item, provided, onRuleEdit, onTextEdit, onDelete, onUpdateId, isGlobal } = props;
   return (
     <ChoiceItem item={item} provided={provided} onRuleEdit={onRuleEdit} onTextEdit={onTextEdit}
-      onDelete={onDelete} onUpdateId={onUpdateId} />
+      onDelete={onDelete} onUpdateId={onUpdateId} isGlobal={isGlobal} />
   );
 }
 
@@ -38,8 +38,9 @@ const buildTreeFromValueSet = (valueSet?: ValueSet): TreeData => {
 
 const ChoiceList: React.FC<{
   valueSet?: ValueSet,
-  updateValueSet: (value: React.SetStateAction<ValueSet | undefined>) => void
-}> = ({ valueSet, updateValueSet }) => {
+  updateValueSet: (value: React.SetStateAction<ValueSet | undefined>) => void,
+  isGlobal?: boolean
+}> = ({ valueSet, updateValueSet, isGlobal }) => {
   const { form, moveValueSetEntry, deleteValueSetEntry, updateValueSetEntry } = useComposer();
   const [tree, setTree] = React.useState<TreeData>(INIT_TREE);
   const languageNo = form.metadata.languages?.length || 0;
@@ -101,7 +102,10 @@ const ChoiceList: React.FC<{
         <TableCell colSpan={2 + languageNo}>
           <Tree
             tree={tree}
-            renderItem={(props) => renderItem({ ...props, onRuleEdit: updateValueSetEntryRule, onTextEdit: updateValueSetEntryLabel, onDelete: onDeleteValueSetEntry, onUpdateId: updateValueSetEntryId })}
+            renderItem={(props) => renderItem({
+              ...props, onRuleEdit: updateValueSetEntryRule, onTextEdit: updateValueSetEntryLabel,
+              onDelete: onDeleteValueSetEntry, onUpdateId: updateValueSetEntryId, isGlobal: isGlobal
+            })}
             onDragEnd={onDragEnd}
             isDragEnabled
           />

--- a/frontend/dialob-composer-material/src/dialob/actions.ts
+++ b/frontend/dialob-composer-material/src/dialob/actions.ts
@@ -22,6 +22,7 @@ export type ComposerAction =
   | { type: 'deleteValueSetentry', valueSetId: string, index: number}
   | { type: 'moveValueSetEntry', valueSetId: string, from: number, to: number}
   | { type: 'setGlobalValueSetName', valueSetId: string, name: string}
+  | { type: 'deleteGlobalValueSet', valueSetId: string}
   // | { type: 'updateValueSetEntryAttr', valueSetId: string, index: number, attr: string, value: any } // probably obsoleted by updateValueSetEntry
 
   | { type: 'setMetadataValue', attr: string, value: any}

--- a/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
+++ b/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
@@ -81,6 +81,10 @@ export const useComposer = () => {
     dispatch({type: 'setGlobalValueSetName', valueSetId, name});
   }
 
+  const deleteGlobalValueSet = (valueSetId: string) => {
+    dispatch({type: 'deleteGlobalValueSet', valueSetId});
+  }
+
   const setMetadataValue = (attr: string, value: any) => {
     dispatch({type: 'setMetadataValue', attr, value});
   }
@@ -129,6 +133,7 @@ export const useComposer = () => {
     deleteValueSetEntry,
     moveValueSetEntry,
     setGlobalValueSetName,
+    deleteGlobalValueSet,
     setMetadataValue,
     createVariable,
     updateContextVariable,

--- a/frontend/dialob-composer-material/src/dialob/reducer.ts
+++ b/frontend/dialob-composer-material/src/dialob/reducer.ts
@@ -329,6 +329,13 @@ const setGlobalValueSetName = (state: ComposerState, valueSetId: string, name: s
   }
 }
 
+const deleteGlobalValueSet = (state: ComposerState, valueSetId: string): void => {
+  if (state.valueSets && state.valueSets?.find(vs => vs.id === valueSetId) !== undefined && state.metadata?.composer?.globalValueSets !== undefined) {
+    state.valueSets = state.valueSets.filter(vs => vs.id !== valueSetId);
+    state.metadata.composer.globalValueSets = state.metadata.composer.globalValueSets.filter(gvs => gvs.valueSetId !== valueSetId);
+  }
+}
+
 const setMetadataValue = (state: ComposerState, attr: string, value: any): void => {
   // TODO: Sanity: Prevent overwriting certain critical attributes
 
@@ -508,6 +515,8 @@ export const formReducer = (state: ComposerState, action: ComposerAction, callba
       moveValueSetEntry(state, action.valueSetId, action.from, action.to);
     } else if (action.type === 'setGlobalValueSetName') {
       setGlobalValueSetName(state, action.valueSetId, action.name);
+    } else if (action.type === 'deleteGlobalValueSet') {
+      deleteGlobalValueSet(state, action.valueSetId);
     } else if (action.type === 'setMetadataValue') {
       setMetadataValue(state, action.attr, action.value);
     } else if (action.type === 'createVariable') {

--- a/frontend/dialob-composer-material/src/dialob/test/reducer.test.ts
+++ b/frontend/dialob-composer-material/src/dialob/test/reducer.test.ts
@@ -2,7 +2,7 @@ import {generateItemId, formReducer} from '../reducer';
 import testForm from './testForm.json';
 import cleanForm from './cleanForm.json';
 import { ComposerAction } from '../actions';
-import { DialobItem, ComposerCallbacks, ComposerState } from '../types';
+import { DialobItem, ComposerCallbacks, ComposerState, LocalizedString } from '../types';
 
 console.log('testform', testForm);
 
@@ -160,6 +160,60 @@ test('Update item, normal new language value', () => {
   };
   const newState = formReducer(testForm, action);
   expect(newState.data.tenantAdminLastName.description?.fi).toBe('Test');
+});
+
+test('Update item label, localized string', () => {
+  const newLabel: LocalizedString = {
+    'en': 'English Label',
+    'fi': 'Finnish Label'
+  };
+  const action: ComposerAction = {
+    type: 'updateLocalizedString',
+    attribute: 'label',
+    itemId: 'usedChannel',
+    value: newLabel,
+  };
+  const newState = formReducer(testForm, action);
+  expect(newState.data.usedChannel.label?.en).toBe('English Label');
+  expect(newState.data.usedChannel.label?.fi).toBe('Finnish Label');
+});
+
+test('Update item description, localized string', () => {
+  const newDesc: LocalizedString = {
+    'en': 'English Desc',
+    'fi': 'Finnish Desc'
+  };
+  const action: ComposerAction = {
+    type: 'updateLocalizedString',
+    attribute: 'description',
+    itemId: 'usedChannel',
+    value: newDesc,
+  };
+  const newState = formReducer(testForm, action);
+  expect(newState.data.usedChannel.description?.en).toBe('English Desc');
+  expect(newState.data.usedChannel.description?.fi).toBe('Finnish Desc');
+});
+
+test('Update validation message, localized string', () => {
+  expect(testForm.data.companyID.validations).toBeDefined();
+  expect(testForm.data.companyID.validations[0]).toBeDefined();
+  const newLabel: LocalizedString = {
+    'en': 'English Label',
+    'fi': 'Finnish Label'
+  };
+  const action: ComposerAction = {
+    type: 'updateLocalizedString',
+    attribute: 'validations',
+    itemId: 'companyID',
+    value: newLabel,
+    index: 0
+  };
+  const newState = formReducer(testForm, action);
+  console.log('new state', newState.data.companyID.validations);
+  expect(newState.data.companyID.validations).toBeDefined();
+  expect(newState.data.companyID.validations?.[0]).toBeDefined();
+  expect(newState.data.companyID.validations?.[0].message?.en).toBe('English Label');
+  expect(newState.data.companyID.validations?.[0].message?.fi).toBe('Finnish Label');
 });
 
 test('Change item type with merging the props #1', () => {
@@ -733,6 +787,33 @@ test('Set global valueset name', () => {
     const gvsIndex = newState.metadata.composer.globalValueSets.findIndex(gvs => gvs.valueSetId === 'vs45');
     expect(gvsIndex).toBeGreaterThan(-1);
     expect(newState.metadata.composer.globalValueSets[gvsIndex].label).toEqual('test');
+  }
+});
+
+test('Delete global valueset', () => {
+  const valueSetId = 'vs45';
+
+  const oldState = testForm;
+  expect(oldState.metadata?.composer?.globalValueSets).toBeDefined();
+  expect(oldState.valueSets).toBeDefined();
+  const gvsToDelete = oldState.metadata.composer.globalValueSets.find(gvs => gvs.valueSetId === valueSetId);
+  expect(gvsToDelete).toBeDefined();
+  const vsToDelete = oldState.valueSets.find(vs => vs.id === valueSetId);
+  expect(vsToDelete).toBeDefined();
+
+  const action: ComposerAction = {
+    type: 'deleteGlobalValueSet',
+    valueSetId: valueSetId
+  };
+
+  const newState = formReducer(testForm, action);
+  expect(newState.metadata?.composer?.globalValueSets).toBeDefined();
+  expect(newState.valueSets).toBeDefined();
+  if (newState.valueSets && newState.metadata?.composer?.globalValueSets) {
+    const deletedGvs = newState.metadata.composer.globalValueSets.find(gvs => gvs.valueSetId === valueSetId);
+    expect(deletedGvs).toBeUndefined();
+    const deletedVs = newState.valueSets.find(vs => vs.id === valueSetId);
+    expect(deletedVs).toBeUndefined();
   }
 });
 

--- a/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import Papa from 'papaparse';
+import FileSaver from 'file-saver';
+import { Add, Close, Download, Upload } from '@mui/icons-material';
+import {
+  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton,
+  Stack, TableCell, TableContainer, TableHead, TableRow, Typography
+} from '@mui/material';
+import { ValueSet, ValueSetEntry, useComposer } from '../dialob';
+import { generateValueSetId } from '../dialob/reducer';
+import { StyledTable } from '../components/TableEditorComponents';
+import ChoiceList from '../components/ChoiceList';
+import UploadValuesetDialog from './UploadValuesetDialog';
+
+interface GlobalValueSet {
+  id: string;
+  label?: string;
+  entries: ValueSetEntry[];
+}
+
+const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ open, onClose }) => {
+  const { form, createValueSet, addValueSetEntry, setGlobalValueSetName } = useComposer();
+  const formLanguages = form.metadata.languages;
+  const [globalValueSets, setGlobalValueSets] = React.useState<GlobalValueSet[] | undefined>(undefined);
+  const [currentValueSet, setCurrentValueSet] = React.useState<ValueSet | undefined>(undefined);
+  const [uploadDialogOpen, setUploadDialogOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    const gvs = form.metadata.composer?.globalValueSets;
+    const valueSets = form.valueSets;
+    const mappedGvs = gvs?.map(gvs => {
+      const found = valueSets?.find(vs => vs.id === gvs.valueSetId)!;
+      return { ...found, label: gvs.label }
+    });
+    setGlobalValueSets(mappedGvs);
+    if (!currentValueSet) {
+      setCurrentValueSet(mappedGvs?.[0]);
+    }
+  }, [form.metadata.composer?.globalValueSets, currentValueSet]);
+
+  const handleAddValueSetEntry = () => {
+    if (currentValueSet) {
+      const newEntry = {
+        id: 'choice' + (currentValueSet.entries.length + 1),
+        label: {},
+      };
+      addValueSetEntry(currentValueSet.id, newEntry);
+      setCurrentValueSet({ ...currentValueSet, entries: [...currentValueSet.entries, newEntry] });
+    }
+  }
+
+  const addGlobalList = () => {
+    const newGvsIndex = form.metadata.composer?.globalValueSets?.length ?? 0;
+    const newGvsName = 'untitled' + (newGvsIndex + 1);
+    const newGvsId = generateValueSetId(form);
+    createValueSet(null);
+    if (newGvsId) {
+      setGlobalValueSetName(newGvsId, newGvsName);
+      setCurrentValueSet({ id: newGvsId, entries: [] });
+    }
+  }
+
+  const downloadValueSet = () => {
+    if (!currentValueSet) {
+      return;
+    }
+    const entries = currentValueSet?.entries;
+    const result: { [key: string]: any }[] = [];
+    entries.forEach(e => {
+      let entry: { [key: string]: any } = { ID: e.id };
+      for (const lang in e.label) {
+        entry[lang] = e.label[lang];
+      }
+      result.push(entry);
+    });
+    const csv = Papa.unparse(result);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    FileSaver.saveAs(blob, `valueSet-${currentValueSet.id}.csv`);
+  }
+
+  return (
+    <>
+      <UploadValuesetDialog open={uploadDialogOpen} onClose={() => setUploadDialogOpen(true)} currentValueSet={currentValueSet} setCurrentValueSet={setCurrentValueSet} />
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth='xl'>
+        <DialogTitle sx={{ display: 'flex' }}>
+          <Typography variant='h5' fontWeight='bold'>Global lists</Typography>
+          <Box flexGrow={1} />
+          <Button onClick={addGlobalList} endIcon={<Add />}>Add new list</Button>
+        </DialogTitle>
+        <DialogContent sx={{ display: 'flex', height: '70vh', borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0 }}>
+          <Stack sx={{ p: 2 }}>
+            {globalValueSets?.map(gvs => (
+              <Button key={gvs.id} variant={gvs.id === currentValueSet?.id ? 'contained' : 'outlined'}
+                onClick={() => setCurrentValueSet({ id: gvs.id, entries: gvs.entries })}>{gvs.label}</Button>
+            ))}
+          </Stack>
+          <TableContainer sx={{ width: 1, p: 2, pl: 0 }}>
+            <StyledTable>
+              <TableHead>
+                <TableRow>
+                  <TableCell width='20%' align='center'>
+                    <IconButton onClick={handleAddValueSetEntry}><Add color='success' /></IconButton>
+                    <IconButton onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
+                    <IconButton onClick={downloadValueSet}><Download /></IconButton>
+                  </TableCell>
+                  <TableCell width='30%' sx={{ p: 1 }}><Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography></TableCell>
+                  {formLanguages?.map(lang => (
+                    <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
+                      <Typography fontWeight='bold'>
+                        <FormattedMessage id='dialogs.options.text' /> - <FormattedMessage id={`locales.${lang}`} />
+                      </Typography>
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <ChoiceList valueSet={currentValueSet} updateValueSet={setCurrentValueSet} isGlobal={true} />
+            </StyledTable>
+          </TableContainer>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} endIcon={<Close />}><FormattedMessage id='buttons.close' /></Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+export default GlobalListsDialog;

--- a/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import Papa from 'papaparse';
 import FileSaver from 'file-saver';
-import { Add, Close, Download, Upload } from '@mui/icons-material';
+import { Add, Close, Delete, Download, Upload, Visibility } from '@mui/icons-material';
 import {
-  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton,
-  Stack, TableCell, TableContainer, TableHead, TableRow, Typography
+  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, List,
+  ListItemButton, Popover, Stack, TableCell, TableContainer, TableHead, TableRow, TextField, Typography
 } from '@mui/material';
 import { ValueSet, ValueSetEntry, useComposer } from '../dialob';
 import { generateValueSetId } from '../dialob/reducer';
 import { StyledTable } from '../components/TableEditorComponents';
 import ChoiceList from '../components/ChoiceList';
 import UploadValuesetDialog from './UploadValuesetDialog';
+import { useEditor } from '../editor';
+import { getErrorColor } from '../utils/ErrorUtils';
 
 interface GlobalValueSet {
   id: string;
@@ -21,10 +23,22 @@ interface GlobalValueSet {
 
 const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ open, onClose }) => {
   const { form, createValueSet, addValueSetEntry, setGlobalValueSetName } = useComposer();
+  const { editor, setActiveList } = useEditor();
+  const dialogOpen = open || editor.activeList !== undefined;
   const formLanguages = form.metadata.languages;
   const [globalValueSets, setGlobalValueSets] = React.useState<GlobalValueSet[] | undefined>(undefined);
   const [currentValueSet, setCurrentValueSet] = React.useState<ValueSet | undefined>(undefined);
   const [uploadDialogOpen, setUploadDialogOpen] = React.useState(false);
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+  const [name, setName] = React.useState<string | undefined>(undefined);
+  const users = currentValueSet && Object.values(form.data).filter(i => i.valueSetId === currentValueSet?.id);
+
+  React.useEffect(() => {
+    const activeList = form.valueSets?.find(vs => vs.id === editor.activeList);
+    if (activeList) {
+      setCurrentValueSet(activeList);
+    }
+  }, [editor.activeList]);
 
   React.useEffect(() => {
     const gvs = form.metadata.composer?.globalValueSets;
@@ -37,7 +51,22 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
     if (!currentValueSet) {
       setCurrentValueSet(mappedGvs?.[0]);
     }
+    setName(mappedGvs?.find(gvs => gvs.id === currentValueSet?.id)?.label || '');
   }, [form.metadata.composer?.globalValueSets, currentValueSet]);
+
+  React.useEffect(() => {
+    if (currentValueSet && name) {
+      const id = setTimeout(() => {
+        setGlobalValueSetName(currentValueSet.id, name);
+      }, 1000);
+      return () => clearTimeout(id);
+    }
+  }, [name])
+
+  const handleClose = () => {
+    setActiveList(undefined);
+    onClose();
+  }
 
   const handleAddValueSetEntry = () => {
     if (currentValueSet) {
@@ -82,44 +111,71 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
   return (
     <>
       <UploadValuesetDialog open={uploadDialogOpen} onClose={() => setUploadDialogOpen(true)} currentValueSet={currentValueSet} setCurrentValueSet={setCurrentValueSet} />
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth='xl'>
-        <DialogTitle sx={{ display: 'flex' }}>
+      <Dialog open={dialogOpen} onClose={handleClose} fullWidth maxWidth='xl'>
+        <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
           <Typography variant='h5' fontWeight='bold'>Global lists</Typography>
           <Box flexGrow={1} />
-          <Button onClick={addGlobalList} endIcon={<Add />}>Add new list</Button>
-        </DialogTitle>
-        <DialogContent sx={{ display: 'flex', height: '70vh', borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0 }}>
-          <Stack sx={{ p: 2 }}>
-            {globalValueSets?.map(gvs => (
-              <Button key={gvs.id} variant={gvs.id === currentValueSet?.id ? 'contained' : 'outlined'}
-                onClick={() => setCurrentValueSet({ id: gvs.id, entries: gvs.entries })}>{gvs.label}</Button>
-            ))}
-          </Stack>
-          <TableContainer sx={{ width: 1, p: 2, pl: 0 }}>
-            <StyledTable>
-              <TableHead>
-                <TableRow>
-                  <TableCell width='20%' align='center'>
-                    <IconButton onClick={handleAddValueSetEntry}><Add color='success' /></IconButton>
-                    <IconButton onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
-                    <IconButton onClick={downloadValueSet}><Download /></IconButton>
-                  </TableCell>
-                  <TableCell width='30%' sx={{ p: 1 }}><Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography></TableCell>
-                  {formLanguages?.map(lang => (
-                    <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
-                      <Typography fontWeight='bold'>
-                        <FormattedMessage id='dialogs.options.text' /> - <FormattedMessage id={`locales.${lang}`} />
-                      </Typography>
-                    </TableCell>
+          <Typography sx={{ mr: 2 }}>Users: <b>{users ? users.length : 0}</b></Typography>
+          {users &&
+            <>
+              <Button onClick={(e) => setAnchorEl(e.currentTarget)} endIcon={<Visibility />}>Show users</Button>
+              <Popover open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'left',
+              }}>
+                <List>
+                  {users.map(i => (
+                    <ListItemButton key={i.id} sx={{ justifyContent: 'flex-start', color: 'text.primary' }}>{i.id}</ListItemButton>
                   ))}
-                </TableRow>
-              </TableHead>
-              <ChoiceList valueSet={currentValueSet} updateValueSet={setCurrentValueSet} isGlobal={true} />
-            </StyledTable>
-          </TableContainer>
+                </List>
+              </Popover>
+            </>
+          }
+          <Button onClick={addGlobalList} endIcon={<Add />} sx={{ ml: 2 }}>Add new list</Button>
+        </DialogTitle>
+        <DialogContent sx={{ borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0 }}>
+          <Box sx={{ display: 'flex', height: '70vh', p: 3 }}>
+            <Stack sx={{ mr: 3 }}>
+              {globalValueSets?.map(gvs => {
+                const errorColor = getErrorColor(editor.errors, gvs.id);
+                return <Button key={gvs.id} variant={gvs.id === currentValueSet?.id ? 'contained' : 'outlined'} color={errorColor}
+                  onClick={() => setCurrentValueSet({ id: gvs.id, entries: gvs.entries })}>
+                  {gvs.label}
+                </Button>
+              })}
+            </Stack>
+            <Box sx={{ width: 1 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+                <TextField value={name || ''} onChange={(e) => setName(e.target.value)} sx={{ width: '70%' }} />
+                <Button endIcon={<Delete />} color='error'>Delete list</Button>
+              </Box>
+              <TableContainer>
+                <StyledTable>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell width='20%' align='center'>
+                        <IconButton onClick={handleAddValueSetEntry}><Add color='success' /></IconButton>
+                        <IconButton onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
+                        <IconButton onClick={downloadValueSet}><Download /></IconButton>
+                      </TableCell>
+                      <TableCell width='30%' sx={{ p: 1 }}><Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography></TableCell>
+                      {formLanguages?.map(lang => (
+                        <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
+                          <Typography fontWeight='bold'>
+                            <FormattedMessage id='dialogs.options.text' /> - <FormattedMessage id={`locales.${lang}`} />
+                          </Typography>
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  </TableHead>
+                  <ChoiceList valueSet={currentValueSet} updateValueSet={setCurrentValueSet} isGlobal={true} />
+                </StyledTable>
+              </TableContainer>
+            </Box>
+          </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose} endIcon={<Close />}><FormattedMessage id='buttons.close' /></Button>
+          <Button onClick={handleClose} endIcon={<Close />}><FormattedMessage id='buttons.close' /></Button>
         </DialogActions>
       </Dialog>
     </>

--- a/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
@@ -2,18 +2,21 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import Papa from 'papaparse';
 import FileSaver from 'file-saver';
-import { Add, Close, Delete, Download, Upload, Visibility } from '@mui/icons-material';
+import { Add, Close, Delete, Download, Upload, Visibility, Warning } from '@mui/icons-material';
 import {
+  Alert,
+  AlertColor,
   Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, List,
   ListItemButton, Popover, Stack, TableCell, TableContainer, TableHead, TableRow, TextField, Typography
 } from '@mui/material';
-import { ValueSet, ValueSetEntry, useComposer } from '../dialob';
+import { DialobItem, ValueSet, ValueSetEntry, useComposer } from '../dialob';
 import { generateValueSetId } from '../dialob/reducer';
 import { StyledTable } from '../components/TableEditorComponents';
 import ChoiceList from '../components/ChoiceList';
 import UploadValuesetDialog from './UploadValuesetDialog';
 import { useEditor } from '../editor';
-import { getErrorColor } from '../utils/ErrorUtils';
+import { ErrorMessage, getErrorColor } from '../utils/ErrorUtils';
+import { scrollToItem } from '../utils/ScrollUtils';
 
 interface GlobalValueSet {
   id: string;
@@ -22,8 +25,8 @@ interface GlobalValueSet {
 }
 
 const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ open, onClose }) => {
-  const { form, createValueSet, addValueSetEntry, setGlobalValueSetName } = useComposer();
-  const { editor, setActiveList } = useEditor();
+  const { form, createValueSet, addValueSetEntry, setGlobalValueSetName, updateItem, deleteGlobalValueSet } = useComposer();
+  const { editor, setActiveList, setActivePage, setHighlightedItem } = useEditor();
   const dialogOpen = open || editor.activeList !== undefined;
   const formLanguages = form.metadata.languages;
   const [globalValueSets, setGlobalValueSets] = React.useState<GlobalValueSet[] | undefined>(undefined);
@@ -32,6 +35,7 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const [name, setName] = React.useState<string | undefined>(undefined);
   const users = currentValueSet && Object.values(form.data).filter(i => i.valueSetId === currentValueSet?.id);
+  const itemErrors = editor.errors.filter(e => e.itemId === currentValueSet?.id);
 
   React.useEffect(() => {
     const activeList = form.valueSets?.find(vs => vs.id === editor.activeList);
@@ -68,7 +72,7 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
     onClose();
   }
 
-  const handleAddValueSetEntry = () => {
+  const addEntry = () => {
     if (currentValueSet) {
       const newEntry = {
         id: 'choice' + (currentValueSet.entries.length + 1),
@@ -79,7 +83,7 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
     }
   }
 
-  const addGlobalList = () => {
+  const addNewList = () => {
     const newGvsIndex = form.metadata.composer?.globalValueSets?.length ?? 0;
     const newGvsName = 'untitled' + (newGvsIndex + 1);
     const newGvsId = generateValueSetId(form);
@@ -90,7 +94,7 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
     }
   }
 
-  const downloadValueSet = () => {
+  const downloadList = () => {
     if (!currentValueSet) {
       return;
     }
@@ -108,70 +112,105 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
     FileSaver.saveAs(blob, `valueSet-${currentValueSet.id}.csv`);
   }
 
+  const convertToLocalList = (valueSet: ValueSet, item: DialobItem) => {
+    const newId = generateValueSetId(form);
+    createValueSet(item?.id, valueSet?.entries);
+    updateItem(item?.id, 'valueSetId', newId);
+  }
+
+  const deleteList = () => {
+    if (currentValueSet) {
+      if (users) {
+        users.forEach(u => convertToLocalList(currentValueSet, u));
+      }
+      deleteGlobalValueSet(currentValueSet.id);
+      setCurrentValueSet(undefined);
+    }
+  }
+
+  const handleScroll = (item: DialobItem) => {
+    handleClose();
+    setAnchorEl(null);
+    setHighlightedItem(item);
+    scrollToItem(item.id, Object.values(form.data), editor.activePage, setActivePage);
+  }
+
   return (
     <>
       <UploadValuesetDialog open={uploadDialogOpen} onClose={() => setUploadDialogOpen(true)} currentValueSet={currentValueSet} setCurrentValueSet={setCurrentValueSet} />
       <Dialog open={dialogOpen} onClose={handleClose} fullWidth maxWidth='xl'>
         <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
-          <Typography variant='h5' fontWeight='bold'>Global lists</Typography>
+          <Typography fontWeight='bold'>Global lists</Typography>
           <Box flexGrow={1} />
-          <Typography sx={{ mr: 2 }}>Users: <b>{users ? users.length : 0}</b></Typography>
-          {users &&
-            <>
-              <Button onClick={(e) => setAnchorEl(e.currentTarget)} endIcon={<Visibility />}>Show users</Button>
-              <Popover open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'left',
-              }}>
-                <List>
-                  {users.map(i => (
-                    <ListItemButton key={i.id} sx={{ justifyContent: 'flex-start', color: 'text.primary' }}>{i.id}</ListItemButton>
-                  ))}
-                </List>
-              </Popover>
-            </>
-          }
-          <Button onClick={addGlobalList} endIcon={<Add />} sx={{ ml: 2 }}>Add new list</Button>
+          {globalValueSets && globalValueSets.length > 0 && <>
+            <Typography sx={{ mr: 2 }}>Users: <b>{users ? users.length : 0}</b></Typography>
+            {users &&
+              <>
+                <Button onClick={(e) => setAnchorEl(e.currentTarget)} endIcon={<Visibility />}>Show users</Button>
+                <Popover open={Boolean(anchorEl)} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                }}>
+                  <List>
+                    {users.map(i => (
+                      <ListItemButton key={i.id}
+                        sx={{ justifyContent: 'flex-start', color: 'text.primary' }}
+                        onClick={() => handleScroll(i)}
+                      >
+                        {i.id}
+                      </ListItemButton>
+                    ))}
+                  </List>
+                </Popover>
+              </>
+            }
+          </>}
+          <Button onClick={addNewList} endIcon={<Add />} sx={{ ml: 2 }}>Add new list</Button>
         </DialogTitle>
         <DialogContent sx={{ borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0 }}>
           <Box sx={{ display: 'flex', height: '70vh', p: 3 }}>
-            <Stack sx={{ mr: 3 }}>
-              {globalValueSets?.map(gvs => {
-                const errorColor = getErrorColor(editor.errors, gvs.id);
-                return <Button key={gvs.id} variant={gvs.id === currentValueSet?.id ? 'contained' : 'outlined'} color={errorColor}
-                  onClick={() => setCurrentValueSet({ id: gvs.id, entries: gvs.entries })}>
-                  {gvs.label}
-                </Button>
-              })}
-            </Stack>
-            <Box sx={{ width: 1 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
-                <TextField value={name || ''} onChange={(e) => setName(e.target.value)} sx={{ width: '70%' }} />
-                <Button endIcon={<Delete />} color='error'>Delete list</Button>
-              </Box>
-              <TableContainer>
-                <StyledTable>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell width='20%' align='center'>
-                        <IconButton onClick={handleAddValueSetEntry}><Add color='success' /></IconButton>
-                        <IconButton onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
-                        <IconButton onClick={downloadValueSet}><Download /></IconButton>
-                      </TableCell>
-                      <TableCell width='30%' sx={{ p: 1 }}><Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography></TableCell>
-                      {formLanguages?.map(lang => (
-                        <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
-                          <Typography fontWeight='bold'>
-                            <FormattedMessage id='dialogs.options.text' /> - <FormattedMessage id={`locales.${lang}`} />
-                          </Typography>
+            {globalValueSets && globalValueSets.length > 0 && <>
+              <Stack sx={{ mr: 3 }}>
+                {globalValueSets?.map(gvs => {
+                  const errorColor = getErrorColor(editor.errors, gvs.id);
+                  return <Button key={gvs.id} variant={gvs.id === currentValueSet?.id ? 'contained' : 'outlined'} color={errorColor}
+                    onClick={() => setCurrentValueSet({ id: gvs.id, entries: gvs.entries })}>
+                    {gvs.label}
+                  </Button>
+                })}
+              </Stack>
+              <Box sx={{ width: 1 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+                  <TextField value={name || ''} onChange={(e) => setName(e.target.value)} sx={{ width: '70%' }} />
+                  <Button endIcon={<Delete />} color='error' onClick={deleteList}>Delete list</Button>
+                </Box>
+                <TableContainer>
+                  <StyledTable>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell width='20%' align='center'>
+                          <IconButton onClick={addEntry}><Add color='success' /></IconButton>
+                          <IconButton onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
+                          <IconButton onClick={downloadList}><Download /></IconButton>
                         </TableCell>
-                      ))}
-                    </TableRow>
-                  </TableHead>
-                  <ChoiceList valueSet={currentValueSet} updateValueSet={setCurrentValueSet} isGlobal={true} />
-                </StyledTable>
-              </TableContainer>
-            </Box>
+                        <TableCell width='30%' sx={{ p: 1 }}><Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography></TableCell>
+                        {formLanguages?.map(lang => (
+                          <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
+                            <Typography fontWeight='bold'>
+                              <FormattedMessage id='dialogs.options.text' /> - <FormattedMessage id={`locales.${lang}`} />
+                            </Typography>
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    </TableHead>
+                    <ChoiceList valueSet={currentValueSet} updateValueSet={setCurrentValueSet} isGlobal={true} />
+                  </StyledTable>
+                </TableContainer>
+                {itemErrors.map((error, index) => <Alert key={index} severity={error.severity.toLowerCase() as AlertColor} sx={{ mt: 2 }} icon={<Warning />}>
+                  <Typography><ErrorMessage error={error} /></Typography>
+                </Alert>)}
+              </Box>
+            </>}
           </Box>
         </DialogContent>
         <DialogActions>

--- a/frontend/dialob-composer-material/src/editor/actions.ts
+++ b/frontend/dialob-composer-material/src/editor/actions.ts
@@ -9,4 +9,5 @@ export type EditorAction =
   | { type: 'setActiveItem', item?: DialobItem }
   | { type: 'setConfirmationDialogType', dialogType?: ConfirmationDialogType }
   | { type: 'setItemOptionsActiveTab', tab?: OptionsTabType }
-  | { type: 'setHighlightedItem', item?: DialobItem };
+  | { type: 'setHighlightedItem', item?: DialobItem }
+  | { type: 'setActiveList', listId?: string }

--- a/frontend/dialob-composer-material/src/editor/react/EditorContext.tsx
+++ b/frontend/dialob-composer-material/src/editor/react/EditorContext.tsx
@@ -17,6 +17,12 @@ const DEMO_ERRORS: EditorError[] = [
     itemId: 'group9',
   },
   {
+    severity: 'WARNING' as ErrorSeverity,
+    message: 'VALUESET_EMPTY',
+    type: 'VALUESET',
+    itemId: 'vs45',
+  },
+  {
     severity: 'INFO' as ErrorSeverity,
     message: 'VALUESET_DUPLICATE_KEY',
     type: 'VALUESET',

--- a/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
+++ b/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
@@ -38,6 +38,10 @@ export const useEditor = () => {
     dispatch({ type: 'setHighlightedItem', item });
   }
 
+  const setActiveList = (listId?: string): void => {
+    dispatch({ type: 'setActiveList', listId });
+  }
+
   return {
     editor: state,
     setActivePage,
@@ -48,5 +52,6 @@ export const useEditor = () => {
     setConfirmationDialogType,
     setItemOptionsActiveTab,
     setHighlightedItem,
+    setActiveList,
   };
 }

--- a/frontend/dialob-composer-material/src/editor/reducer.ts
+++ b/frontend/dialob-composer-material/src/editor/reducer.ts
@@ -35,6 +35,10 @@ const setHighlightedItem = (state: EditorState, item?: DialobItem): void => {
   state.highlightedItem = item;
 }
 
+const setActiveList = (state: EditorState, listId?: string): void => {
+  state.activeList = listId;
+}
+
 export const editorReducer = (state: EditorState, action: EditorAction): EditorState => {
   const newState = produce(state, state => {
     if (action.type === 'setActivePage') {
@@ -53,6 +57,8 @@ export const editorReducer = (state: EditorState, action: EditorAction): EditorS
       setItemOptionsActiveTab(state, action.tab);
     } else if (action.type === 'setHighlightedItem') {
       setHighlightedItem(state, action.item);
+    } else if (action.type === 'setActiveList') {
+      setActiveList(state, action.listId);
     }
   });
   return newState;

--- a/frontend/dialob-composer-material/src/editor/types.ts
+++ b/frontend/dialob-composer-material/src/editor/types.ts
@@ -20,4 +20,5 @@ export type EditorState = {
   confirmationDialogType?: ConfirmationDialogType;
   itemOptionsActiveTab?: OptionsTabType;
   highlightedItem?: DialobItem;
+  activeList?: string;
 };

--- a/frontend/dialob-composer-material/src/items/Group.tsx
+++ b/frontend/dialob-composer-material/src/items/Group.tsx
@@ -6,7 +6,7 @@ import { DialobItem, DialobItems, useComposer } from '../dialob';
 import { AddItemMenu, ConversionMenu, IdField, Indicators, LabelField, OptionsMenu, StyledTable, VisibilityField } from './ItemComponents';
 import { itemFactory } from './ItemFactory';
 import { useEditor } from '../editor';
-import { useErrorColor } from '../utils/ErrorUtils';
+import { useErrorColorSx } from '../utils/ErrorUtils';
 
 
 const createChildren = (item: DialobItem, items: DialobItems) => {
@@ -22,7 +22,7 @@ const Group: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => 
   const [expanded, setExpanded] = React.useState<boolean>(true);
   const children = createChildren(item, form.data);
   const centeredCellSx = { textAlign: 'center' };
-  const errorBorderColor = useErrorColor(editor.errors, item);
+  const errorBorderColor = useErrorColorSx(editor.errors, item.id);
   const hasIndicators = item.description || item.valueSetId || item.validations;
   const [highlighted, setHighlighted] = React.useState<boolean>(false);
   const highlightedSx = highlighted ?

--- a/frontend/dialob-composer-material/src/items/SimpleField.tsx
+++ b/frontend/dialob-composer-material/src/items/SimpleField.tsx
@@ -4,14 +4,14 @@ import { Element } from 'react-scroll';
 import { DialobItem } from '../dialob';
 import { ConversionMenu, IdField, LabelField, Indicators, OptionsMenu, VisibilityField, StyledTable } from './ItemComponents';
 import { useEditor } from '../editor';
-import { useErrorColor } from '../utils/ErrorUtils';
+import { useErrorColorSx } from '../utils/ErrorUtils';
 
 
 const SimpleField: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => {
   const theme = useTheme();
   const { editor } = useEditor();
   const centeredCellSx = { textAlign: 'center' };
-  const errorBorderColor = useErrorColor(editor.errors, item);
+  const errorBorderColor = useErrorColorSx(editor.errors, item.id);
   const hasIndicators = item.description || item.valueSetId || item.validations;
   const [highlighted, setHighlighted] = React.useState<boolean>(false);
   const highlightedSx = highlighted ?

--- a/frontend/dialob-composer-material/src/theme/siteTheme.ts
+++ b/frontend/dialob-composer-material/src/theme/siteTheme.ts
@@ -78,13 +78,13 @@ const palette = {
     main: '#554971',
     light: '#796AA0',
     dark: '#413857',
-    contrastText: 'rgba(0, 0, 0, 0.23)',
+    contrastText: '#fff',
   },
   warning: {
     main: '#ff9800',
     light: '#ffac33',
     dark: '#b26a00',
-    contrastText: '#000001',
+    contrastText: '#fff',
   },
   success: {
     main: '#4caf50',

--- a/frontend/dialob-composer-material/src/utils/ErrorUtils.tsx
+++ b/frontend/dialob-composer-material/src/utils/ErrorUtils.tsx
@@ -58,14 +58,30 @@ const getDominantSeverity = (errors: EditorError[]): ErrorSeverity | undefined =
   return undefined;
 }
 
-const getItemErrorSeverity = (errors: EditorError[], item: DialobItem): ErrorSeverity | undefined => {
-  const itemErrors = errors.filter(error => error.itemId === item.id);
+const getItemErrorSeverity = (errors: EditorError[], itemId: string): ErrorSeverity | undefined => {
+  const itemErrors = errors.filter(error => error.itemId === itemId);
   return getDominantSeverity(itemErrors);
 }
 
-export const useErrorColor = (errors: EditorError[], item: DialobItem): string | undefined => {
+export const getErrorColor = (errors: EditorError[], itemId: string) => {
+  const itemErrorSeverity = getItemErrorSeverity(errors, itemId);
+  switch (itemErrorSeverity) {
+    case 'FATAL':
+      return 'error';
+    case 'ERROR':
+      return 'error';
+    case 'WARNING':
+      return 'warning';
+    case 'INFO':
+      return 'info';
+    default:
+      return 'primary';
+  }
+}
+
+export const useErrorColorSx = (errors: EditorError[], itemId: string): string | undefined => {
   const theme = useTheme();
-  const itemErrorSeverity = getItemErrorSeverity(errors, item);
+  const itemErrorSeverity = getItemErrorSeverity(errors, itemId);
   switch (itemErrorSeverity) {
     case 'FATAL':
       return theme.palette.error.main;
@@ -80,8 +96,8 @@ export const useErrorColor = (errors: EditorError[], item: DialobItem): string |
   }
 }
 
-export const getErrorIcon = (errors: EditorError[], item: DialobItem): React.ReactNode | undefined => {
-  const itemErrorSeverity = getItemErrorSeverity(errors, item);
+export const getErrorIcon = (errors: EditorError[], itemId: string): React.ReactNode | undefined => {
+  const itemErrorSeverity = getItemErrorSeverity(errors, itemId);
   switch (itemErrorSeverity) {
     case 'FATAL':
       return <PreTextIcon disableRipple><Warning color='error' fontSize='small' /></PreTextIcon>;

--- a/frontend/dialob-composer-material/src/views/layout/ErrorPane.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/ErrorPane.tsx
@@ -18,7 +18,7 @@ const errorCardBorderColor = (severity: string) => {
 };
 
 const ErrorPane: React.FC = () => {
-  const { editor, setActivePage } = useEditor();
+  const { editor, setActivePage, setActiveList } = useEditor();
   const { form } = useComposer();
 
   const handleScrollTo = (itemId?: string) => {
@@ -28,11 +28,23 @@ const ErrorPane: React.FC = () => {
     scrollToItem(itemId, Object.values(form.data), editor.activePage, setActivePage);
   }
 
+  const handleEditList = (listId?: string) => {
+    if (listId) {
+      setActiveList(listId);
+    }
+  }
+
+  const handleClick = (id?: string) => {
+    if (id) {
+      id.startsWith('vs') ? handleEditList(id) : handleScrollTo(id);
+    }
+  }
+
   return (
     <Box sx={{ m: 1 }}>
       {editor.errors.map(error => (
         <Card key={error.itemId} sx={{ mb: 2 }}>
-          <CardActionArea onClick={() => handleScrollTo(error.itemId)}>
+          <CardActionArea onClick={() => handleClick(error.itemId)}>
             <CardContent sx={{ borderLeft: 2, borderColor: errorCardBorderColor(error.severity) }}>
               <Typography variant='subtitle1'><ErrorType error={error} /></Typography>
               <Typography variant='subtitle2' component='span'><ErrorMessage error={error} /></Typography>

--- a/frontend/dialob-composer-material/src/views/layout/MenuBar.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/MenuBar.tsx
@@ -6,6 +6,7 @@ import { useComposer } from '../../dialob';
 import { getStatusIcon } from '../../utils/ErrorUtils';
 import { useEditor } from '../../editor';
 import { SCROLLBAR_WIDTH } from '../../theme/siteTheme';
+import GlobalListsDialog from '../../dialogs/GlobalListsDialog';
 
 const ResponsiveButton = styled(Button)(({ theme }) => ({
   [theme.breakpoints.down('lg')]: {
@@ -49,7 +50,7 @@ const MenuBar: React.FC = () => {
   const { editor, setActiveFormLanguage } = useEditor();
   const headerPaddingSx = { px: theme.spacing(1) };
   const formLanguages = form.metadata.languages || ['en'];
-
+  const [listsDialogOpen, setListsDialogOpen] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const languageMenuOpen = Boolean(anchorEl);
 
@@ -63,43 +64,46 @@ const MenuBar: React.FC = () => {
   }
 
   return (
-    <AppBar position="fixed" color='inherit' sx={{ zIndex: theme.zIndex.drawer + 1, marginRight: -SCROLLBAR_WIDTH }}>
-      <Stack direction='row' divider={<Divider orientation='vertical' flexItem />}>
-        <Box sx={{ display: 'flex', alignItems: 'center', ...headerPaddingSx }}>
-          <Typography sx={{ fontWeight: 'bold' }}>
-            Dialob Composer
-          </Typography>
-          <Typography sx={{ ml: 1 }}>
-            {form.metadata.label}
-          </Typography>
-        </Box>
-        <HeaderButton label='translations' />
-        <HeaderButton label='variables' />
-        <HeaderButton label='lists' />
-        <HeaderButton label='options' />
-        <HeaderButton label={intl.formatMessage({ id: 'version' }) + ": " + intl.formatMessage({ id: 'version.latest' })} endIcon={<ArrowDropDown />} />
-        <HeaderIconButton icon={<Support fontSize='small' />} />
-        <Box flexGrow={1} />
-        <Box sx={{ display: 'flex', alignItems: 'center', ...headerPaddingSx }}>
-          <InputBase placeholder={intl.formatMessage({ id: 'search' })} />
-          <Search />
-        </Box>
-        <HeaderIconButton icon={<Download />} />
-        <HeaderIconButton disabled icon={getStatusIcon(editor.errors)} />
-        <HeaderButton label={'locales.' + editor.activeFormLanguage} endIcon={<ArrowDropDown />} onClick={handleLanguageMenuOpen} />
-        <Menu open={languageMenuOpen} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} disableScrollLock={true}>
-          {formLanguages
-            .filter((language) => language !== editor.activeFormLanguage)
-            .map((language) => (
-              <MenuItem key={language} onClick={() => handleLanguageSelect(language)}>
-                {intl.formatMessage({ id: 'locales.' + language })}
-              </MenuItem>
-            ))}
-        </Menu>
-        <HeaderIconButton icon={<Visibility fontSize='small' />} />
-        <HeaderIconButton icon={<Close />} />
-      </Stack>
-    </AppBar>
+    <>
+      <GlobalListsDialog open={listsDialogOpen} onClose={() => setListsDialogOpen(false)} />
+      <AppBar position="fixed" color='inherit' sx={{ zIndex: theme.zIndex.drawer + 1, marginRight: -SCROLLBAR_WIDTH }}>
+        <Stack direction='row' divider={<Divider orientation='vertical' flexItem />}>
+          <Box sx={{ display: 'flex', alignItems: 'center', ...headerPaddingSx }}>
+            <Typography sx={{ fontWeight: 'bold' }}>
+              Dialob Composer
+            </Typography>
+            <Typography sx={{ ml: 1 }}>
+              {form.metadata.label}
+            </Typography>
+          </Box>
+          <HeaderButton label='translations' />
+          <HeaderButton label='variables' />
+          <HeaderButton label='lists' onClick={() => setListsDialogOpen(true)} />
+          <HeaderButton label='options' />
+          <HeaderButton label={intl.formatMessage({ id: 'version' }) + ": " + intl.formatMessage({ id: 'version.latest' })} endIcon={<ArrowDropDown />} />
+          <HeaderIconButton icon={<Support fontSize='small' />} />
+          <Box flexGrow={1} />
+          <Box sx={{ display: 'flex', alignItems: 'center', ...headerPaddingSx }}>
+            <InputBase placeholder={intl.formatMessage({ id: 'search' })} />
+            <Search />
+          </Box>
+          <HeaderIconButton icon={<Download />} />
+          <HeaderIconButton disabled icon={getStatusIcon(editor.errors)} />
+          <HeaderButton label={'locales.' + editor.activeFormLanguage} endIcon={<ArrowDropDown />} onClick={handleLanguageMenuOpen} />
+          <Menu open={languageMenuOpen} anchorEl={anchorEl} onClose={() => setAnchorEl(null)} disableScrollLock={true}>
+            {formLanguages
+              .filter((language) => language !== editor.activeFormLanguage)
+              .map((language) => (
+                <MenuItem key={language} onClick={() => handleLanguageSelect(language)}>
+                  {intl.formatMessage({ id: 'locales.' + language })}
+                </MenuItem>
+              ))}
+          </Menu>
+          <HeaderIconButton icon={<Visibility fontSize='small' />} />
+          <HeaderIconButton icon={<Close />} />
+        </Stack>
+      </AppBar>
+    </>
   );
 };
 

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeItem.tsx
@@ -6,7 +6,7 @@ import { TreeDraggableProvided } from '@atlaskit/tree/dist/types/components/Tree
 import { DialobItem, useComposer } from '../../dialob';
 import { DEFAULT_ITEM_CONFIG, PAGE_CONFIG } from '../../defaults';
 import { useEditor } from '../../editor';
-import { getErrorIcon, useErrorColor } from '../../utils/ErrorUtils';
+import { getErrorIcon, useErrorColorSx } from '../../utils/ErrorUtils';
 import { scrollToItem } from '../../utils/ScrollUtils';
 
 
@@ -68,7 +68,7 @@ const getTitle = (item: TreeItem) => {
 const NavigationTreeItem: React.FC<TreeItemProps> = ({ item, onExpand, onCollapse, provided }) => {
   const { editor, setActivePage, setHighlightedItem } = useEditor();
   const { form } = useComposer();
-  const errorColor = useErrorColor(editor.errors, item.data.item);
+  const errorColor = useErrorColorSx(editor.errors, item.data.item.id);
   const itemId = item.data.item.id;
 
   const handleScrollTo = (e: React.MouseEvent) => {
@@ -84,7 +84,7 @@ const NavigationTreeItem: React.FC<TreeItemProps> = ({ item, onExpand, onCollaps
       {...provided.dragHandleProps}
     >
       {getIcon(item, onExpand, onCollapse)}
-      {errorColor ? getErrorIcon(editor.errors, item.data.item) : getTypeIcon(item.data.item, item.data.isPage)}
+      {errorColor ? getErrorIcon(editor.errors, item.data.item.id) : getTypeIcon(item.data.item, item.data.isPage)}
       <ListItemText sx={{ cursor: 'pointer', ':hover': { color: 'text.secondary' } }} onClick={handleScrollTo}>
         <Typography sx={{ color: errorColor, ':hover': { color: 'text.secondary' } }}>{getTitle(item)}</Typography>
       </ListItemText>

--- a/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
+++ b/frontend/dialob-composer-material/src/views/tree/NavigationTreeView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, useTheme } from '@mui/material';
+import { Box, Button, Paper, useTheme } from '@mui/material';
 import Tree, {
   mutateTree,
   moveItemOnTree,
@@ -14,6 +14,7 @@ import { useEditor } from '../../editor';
 import { buildTreeFromForm } from './TreeBuilder';
 import NavigationTreeItem from './NavigationTreeItem';
 import { DEFAULT_ITEM_CONFIG, canContain } from '../../defaults';
+import { KeyboardArrowDown, KeyboardArrowRight } from '@mui/icons-material';
 
 
 const INIT_TREE: TreeData = {
@@ -51,6 +52,7 @@ const renderItem = ({ item, onExpand, onCollapse, provided }: RenderItemParams) 
 }
 
 const NavigationTreeView: React.FC = () => {
+
   const theme = useTheme();
   const { form, moveItem } = useComposer();
   const { editor } = useEditor();
@@ -66,6 +68,26 @@ const NavigationTreeView: React.FC = () => {
 
   const onCollapse = (itemId: ItemId) => {
     setTree((prevTree) => mutateTree(prevTree, itemId, { isExpanded: false }));
+  };
+
+  const expandAll = () => {
+    setTree((prevTree) => {
+      const newTree = { ...prevTree };
+      Object.keys(newTree.items).forEach(key => {
+        newTree.items[key].isExpanded = true;
+      });
+      return newTree;
+    });
+  };
+
+  const collapseAll = () => {
+    setTree((prevTree) => {
+      const newTree = { ...prevTree };
+      Object.keys(newTree.items).forEach(key => {
+        newTree.items[key].isExpanded = false;
+      });
+      return newTree;
+    });
   };
 
   const onDragEnd = (
@@ -91,7 +113,11 @@ const NavigationTreeView: React.FC = () => {
   };
 
   return (
-    <Box sx={{ mt: 2 }}>
+    <Box>
+      <Paper elevation={3} sx={{ my: 1, p: 1, display: 'flex', justifyContent: 'space-evenly' }}>
+        <Button variant='text' onClick={expandAll} endIcon={<KeyboardArrowDown />}>Expand All</Button>
+        <Button variant='text' onClick={collapseAll} endIcon={<KeyboardArrowRight />}>Collapse All</Button>
+      </Paper>
       <Tree
         tree={tree}
         renderItem={renderItem}


### PR DESCRIPTION
### New global list edit dialog
- retained old functionality:
  - editing the list name
  - adding a new list
  - error indicators and alerts
- users shown in the top bar, along with a clearly indicated button to show the users
- clicking a user scrolls to the item that uses the list
- added a delete button - it firstly converts all usages of the global list to local lists, and then deletes it

![image](https://github.com/dialob/dialob-parent/assets/80248680/8b839846-d4ae-406a-807d-c26148df28cb)
<img src='https://github.com/dialob/dialob-parent/assets/80248680/2c9a6e35-f3d6-422a-b47e-5cbc3b357e6d' width='200px' />

### Additional improvements

1. Choice editor
- added a button with a popover to the choice editor (in the item edit dialog) which allows directly selecting a global list
- currently, you have to first convert the existing local list to a global, and then select another global list, so this addresses that problem
![image](https://github.com/dialob/dialob-parent/assets/80248680/a19145ce-983d-4ffa-8ca6-76dbc5816bc8)

2. Navigation tree
- added a toolbar at the top that has buttons to expand all or collapse all items
- <img src='https://github.com/dialob/dialob-parent/assets/80248680/6f1c8378-dbeb-4bc4-9c4b-875a0a23cbbd' width='200px' />
