### PR TITLE
String cleanup for labels

### DIFF
--- a/frontend/dialob-composer-material/src/utils/StringUtils.tsx
+++ b/frontend/dialob-composer-material/src/utils/StringUtils.tsx
@@ -1,0 +1,27 @@
+import { LocalizedString } from "../dialob";
+
+export const cleanString = (str: string): string => {
+  const nonBreakingSpaceRegex = /[\u00A0]/g;
+  let cleanedStr = str;
+
+  if (nonBreakingSpaceRegex.test(str)) {
+    cleanedStr = str.replace(nonBreakingSpaceRegex, ' ');
+  }
+
+  const zeroWidthCharsRegex = /[\u200B-\u200D\uFEFF]/g;
+
+  if (zeroWidthCharsRegex.test(cleanedStr)) {
+    cleanedStr = cleanedStr.replace(zeroWidthCharsRegex, '');
+  }
+
+  return cleanedStr;
+}
+
+export const cleanLocalizedString = (str: LocalizedString): LocalizedString => {
+  const cleanedStr = { ...str };
+  Object.keys(str).map((key) => {
+    cleanedStr[key] = cleanString(str[key]);
+  });
+  return cleanedStr;
+}
+``


### PR DESCRIPTION
- added utils that perform string cleanup replacing non-breaking space characters with normal space, and removing common invisible unicode characters
- integrated string cleanup in reducer, so that when any label (item label, description, validation message, valueset label) is edited it will be cleaned up on save
- since file translations use the same reducer, this inherently applies to uploaded translations as well (this also means that downloading and reuploading the same file will perform automatic cleanup for all existing strings)