### PR TITLE
Attribute editing UX improvements

### DIFF
--- a/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
@@ -105,16 +105,16 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
         {...provided.dragHandleProps}>
         <TableBody>
           <TableRow key={entry.id} sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
-            <TableCell align='center' width='20%'>
-              <IconButton onClick={() => onToggleExpand(entry.id)}>{entryExpanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}</IconButton>
-              <IconButton onClick={() => setOpen(true)}><Close color='error' /></IconButton>
+            <TableCell align='center' width='15%'>
+              <IconButton sx={{ p: 0.5 }} onClick={() => onToggleExpand(entry.id)}>{entryExpanded ? <KeyboardArrowUp /> : <KeyboardArrowDown />}</IconButton>
+              <IconButton sx={{ p: 0.5 }} onClick={() => setOpen(true)}><Close color='error' /></IconButton>
               {!isGlobal && <IconButton onClick={() => onToggleExpand(entry.id)}><Visibility color={entry.when ? 'primary' : 'inherit'} /></IconButton>}
             </TableCell>
-            <TableCell width='30%' sx={{ p: 1 }}>
+            <TableCell width='20%' sx={{ p: 0.5 }}>
               <Typography>{entry.id}</Typography>
             </TableCell>
             {formLanguages?.map(lang => (
-              <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
+              <TableCell key={lang} width={formLanguages ? `${65 / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
                 {getLabel(entry, lang)}
               </TableCell>
             ))}

--- a/frontend/dialob-composer-material/src/components/editors/ChoiceEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/ChoiceEditor.tsx
@@ -175,16 +175,16 @@ const ChoiceEditor: React.FC = () => {
           <BorderedTable>
             <TableHead>
               <TableRow>
-                <TableCell width='20%' align='center'>
-                  <IconButton onClick={handleAddValueSetEntry}><Add color='success' /></IconButton>
-                  <IconButton onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
-                  <IconButton onClick={() => downloadValueSet(currentValueSet)}><Download /></IconButton>
+                <TableCell width='15%' align='center'>
+                  <IconButton sx={{ p: 0.5 }} onClick={handleAddValueSetEntry}><Add color='success' /></IconButton>
+                  <IconButton sx={{ p: 0.5 }} onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
+                  <IconButton sx={{ p: 0.5 }} onClick={() => downloadValueSet(currentValueSet)}><Download /></IconButton>
                 </TableCell>
-                <TableCell width='30%' sx={{ p: 1 }}>
+                <TableCell width='20%' sx={{ p: 1 }}>
                   <Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography>
                 </TableCell>
                 {formLanguages?.map(lang => (
-                  <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
+                  <TableCell key={lang} width={formLanguages ? `${65 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
                     <Typography fontWeight='bold'>
                       <FormattedMessage id='dialogs.options.text' values={{ language: lang }} />
                     </Typography>

--- a/frontend/dialob-composer-material/src/components/editors/DefaultValueEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/DefaultValueEditor.tsx
@@ -38,7 +38,7 @@ const DefaultValueEditor: React.FC = () => {
 
   return (
     <Box>
-      <Typography><FormattedMessage id='dialogs.options.default.set' /></Typography>
+      <Typography color="text.hint"><FormattedMessage id='dialogs.options.default' /></Typography>
       <TextField variant='outlined' value={defaultValue} onChange={(e) => setDefaultValue(e.target.value)} />
       {itemErrors?.map((error, index) => <Alert severity={getErrorSeverity(error)} sx={{ mt: 2 }} icon={<Warning />}>
         <Typography key={index} color={error.level.toLowerCase()}><ErrorMessage error={error} /></Typography>

--- a/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Markdown from 'react-markdown';
-import { Button, Typography, Box, TextareaAutosize, Menu, MenuItem, IconButton } from '@mui/material';
-import { Add, Delete, Translate, Visibility } from '@mui/icons-material';
+import { Button, Typography, Box, TextareaAutosize, IconButton } from '@mui/material';
+import { Delete, Visibility } from '@mui/icons-material';
 import { FormattedMessage } from 'react-intl';
 import { LocalizedString, useComposer } from '../../dialob';
 import { useEditor } from '../../editor';
@@ -17,12 +17,10 @@ const LocalizedStringEditor: React.FC<{
 }> = ({ type, rule, setRule }) => {
   const { form, updateLocalizedString } = useComposer();
   const { editor, setActiveItem } = useEditor();
-  const activeLanguage = editor.activeFormLanguage;
   const item = editor.activeItem;
   const formLanguages = form.metadata.languages;
   const [preview, setPreview] = React.useState(false);
   const [localizedString, setLocalizedString] = React.useState<LocalizedString | undefined>();
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   React.useEffect(() => {
     if (item) {
@@ -52,10 +50,6 @@ const LocalizedStringEditor: React.FC<{
     return null;
   }
 
-  const handleAdd = (language: string) => {
-    setLocalizedString({ ...localizedString, [language]: '' });
-  }
-
   const handleUpdate = (value: string, language: string) => {
     setLocalizedString({ ...localizedString, [language]: value });
   }
@@ -73,32 +67,9 @@ const LocalizedStringEditor: React.FC<{
         <Button variant={preview ? 'contained' : 'outlined'} endIcon={<Visibility />} onClick={() => setPreview(!preview)}>
           <FormattedMessage id='dialogs.options.preview' />
         </Button>
-        {(localizedString === undefined || localizedString[activeLanguage] === undefined) && <Button variant='outlined'
-          onClick={() => handleAdd(activeLanguage)} sx={{ textTransform: 'none', ml: 1 }} endIcon={<Translate />}
-          disabled={form.metadata.languages?.length === (localizedString ? Object.keys(localizedString).length : 0)}>
-          <FormattedMessage id={`dialogs.options.translation.${activeLanguage}.add`} />
-        </Button>}
-        {formLanguages && formLanguages.length > 1 && <Button variant='outlined' onClick={(e) => setAnchorEl(e.currentTarget)}
-          disabled={form.metadata.languages?.length === (localizedString ? Object.keys(localizedString).length : 0)}
-          sx={{ textTransform: 'none', ml: 1 }} endIcon={<Add />}>
-          <FormattedMessage id={`dialogs.options.${type}.add`} />
-        </Button>}
-        <Menu
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={() => setAnchorEl(null)}
-        >
-          {form.metadata.languages?.filter((language) => !localizedString?.[language])
-            .map((language) => (
-              <MenuItem key={language} onClick={() => {
-                handleAdd(language);
-                setAnchorEl(null);
-              }}>{getLanguageName(language)}</MenuItem>
-            ))}
-        </Menu>
       </Box>
-      {localizedString && Object.keys(localizedString).map((language) => {
-        const localizedText = localizedString[language];
+      {formLanguages?.map((language) => {
+        const localizedText = localizedString ? localizedString[language] : '';
         return (
           <Box key={language}>
             <Box display='flex' alignItems='center'>

--- a/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
@@ -71,7 +71,7 @@ const PropertiesEditor: React.FC = () => {
           <Typography sx={{ px: 2 }}><FormattedMessage id='dialogs.options.properties.add.short' /></Typography>
         </Button>
       </Box>
-      <TableContainer>
+      {props.length > 0 && <TableContainer>
         <BorderedTable>
           <TableHead>
             <TableRow>
@@ -84,7 +84,7 @@ const PropertiesEditor: React.FC = () => {
             {props.map(prop => <PropItem key={prop.key} prop={prop} propEditor={propEditors && propEditors[prop.key]} onEdit={handleEditProp} onDelete={handleDeleteProp} />)}
           </TableBody>
         </BorderedTable>
-      </TableContainer>
+      </TableContainer>}
     </Box>
   );
 }

--- a/frontend/dialob-composer-material/src/components/editors/RulesEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/RulesEditor.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { Box, Button } from '@mui/material';
 import { Help } from '@mui/icons-material';
 import { useDocs } from '../../utils/DocsUtils';
+import { DefaultValueEditor } from './DefaultValueEditor';
 
 const RulesEditor: React.FC = () => {
   const docsUrl = useDocs('del');
@@ -20,6 +21,7 @@ const RulesEditor: React.FC = () => {
       <RuleEditor type='requirement' />
       <RuleEditor type='canaddrow' />
       <RuleEditor type='canremoverow' />
+      <DefaultValueEditor />
     </>
   );
 }

--- a/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
@@ -24,25 +24,25 @@ const ContextVariableRow: React.FC<VariableProps> = ({ item, provided, onClose }
       {...provided.dragHandleProps}>
       <TableBody>
         <TableRow key={variable.name} sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
-          <TableCell width='5%' align='center' sx={{ p: 1 }}>
+          <TableCell width='5%' align='center' sx={{ p: 0.5 }}>
             <DeleteButton variable={variable} />
           </TableCell>
-          <TableCell width='7%' align='center' sx={{ p: 1 }}>
+          <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
             <PublishedSwitch variable={variable} />
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='25%' sx={{ p: 0.5 }}>
             <NameField variable={variable} />
           </TableCell>
-          <TableCell width='8%' sx={{ p: 1 }}>
+          <TableCell width='10%' sx={{ p: 0.5 }}>
             <ContextTypeMenu variable={variable} />
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='20%' sx={{ p: 0.5 }}>
             <DefaultValueField variable={variable} />
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='20%' sx={{ p: 0.5 }}>
             <DescriptionField />
           </TableCell>
-          <TableCell width='5%' align='center' sx={{ p: 1 }}>
+          <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
             <UsersField variable={variable} onClose={onClose} />
           </TableCell>
         </TableRow>

--- a/frontend/dialob-composer-material/src/components/variables/ContextVariables.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ContextVariables.tsx
@@ -48,25 +48,25 @@ const ContextVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     <BorderedTable sx={{ tableLayout: 'fixed' }}>
       <TableHead>
         <TableRow>
-          <TableCell width='5%' align='center' sx={{ p: 1 }}>
-            <IconButton sx={{ p: 1, m: 1 }} onClick={handleAdd}><Add color='success' /></IconButton>
+          <TableCell width='5%' align='center' sx={{ p: 0.5 }}>
+            <IconButton sx={{ p: 0.5 }} onClick={handleAdd}><Add color='success' /></IconButton>
           </TableCell>
-          <TableCell width='7%' sx={{ p: 1 }}>
+          <TableCell width='10%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.published' /></Typography>
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='25%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.id' /></Typography>
           </TableCell>
-          <TableCell width='8%' sx={{ p: 1 }}>
+          <TableCell width='10%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.type' /></Typography>
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='20%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.default' /></Typography>
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='20%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.description' /></Typography>
           </TableCell>
-          <TableCell width='5%' align='center' sx={{ p: 1 }}>
+          <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.users' /></Typography>
           </TableCell>
         </TableRow>

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
@@ -27,23 +27,23 @@ const ExpressionVariableRow: React.FC<VariableProps> = ({ item, provided, onClos
           <TableCell width='5%' align='center' sx={{ p: 1 }}>
             <DeleteButton variable={variable} />
           </TableCell>
-          <TableCell width='7%' align='center' sx={{ p: 1 }}>
+          <TableCell width='10%' align='center' sx={{ p: 1 }}>
             <PublishedSwitch variable={variable} />
           </TableCell>
           <TableCell width='25%' sx={{ p: 1 }}>
             <NameField variable={variable} />
           </TableCell>
-          <TableCell width='33%' sx={{ p: 1 }}>
+          <TableCell width='30%' sx={{ p: 1 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
-              {variable.expression.substring(0, 45) + (variable.expression.length > 45 ? '...' : '')}
+              {variable.expression.substring(0, 20) + (variable.expression.length > 20 ? '...' : '')}
               <IconButton><Edit color={expanded ? 'primary' : 'inherit'} onClick={() => setExpanded(!expanded)} /></IconButton>
             </Box>
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='20%' sx={{ p: 1 }}>
             <DescriptionField />
           </TableCell>
-          <TableCell width='5%' align='center' sx={{ p: 1 }}>
+          <TableCell width='10%' align='center' sx={{ p: 1 }}>
             <UsersField variable={variable} onClose={onClose} />
           </TableCell>
         </TableRow>

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariables.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariables.tsx
@@ -49,22 +49,22 @@ const ExpressionVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => 
     <BorderedTable sx={{ tableLayout: 'fixed' }}>
       <TableHead>
         <TableRow>
-          <TableCell width='5%' align='center' sx={{ p: 1 }}>
-            <IconButton sx={{ p: 1, m: 1 }} onClick={handleAdd}><Add color='success' /></IconButton>
+          <TableCell width='5%' align='center' sx={{ p: 0.5 }}>
+            <IconButton sx={{ p: 0.5 }} onClick={handleAdd}><Add color='success' /></IconButton>
           </TableCell>
-          <TableCell width='7%' align='center' sx={{ p: 1 }}>
+          <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.published' /></Typography>
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='25%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.id' /></Typography>
           </TableCell>
-          <TableCell width='33%' sx={{ p: 1 }}>
+          <TableCell width='30%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.expression' /></Typography>
           </TableCell>
-          <TableCell width='25%' sx={{ p: 1 }}>
+          <TableCell width='20%' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.description' /></Typography>
           </TableCell>
-          <TableCell width='5%' align='center' sx={{ p: 1 }}>
+          <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
             <Typography fontWeight='bold'><FormattedMessage id='dialogs.variables.users' /></Typography>
           </TableCell>
         </TableRow>

--- a/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
@@ -32,14 +32,14 @@ export interface VariableProps {
 export const DeleteButton: React.FC<{ variable: ContextVariable | Variable }> = ({ variable }) => {
   const { deleteVariable } = useComposer();
   return (
-    <IconButton sx={{ p: 1, m: 1 }} onClick={() => deleteVariable(variable.name)}><Delete color='error' /></IconButton>
+    <IconButton sx={{ p: 0.5 }} onClick={() => deleteVariable(variable.name)}><Delete color='error' /></IconButton>
   );
 }
 
 export const PublishedSwitch: React.FC<{ variable: ContextVariable | Variable }> = ({ variable }) => {
   const { updateVariablePublishing } = useComposer();
   return (
-    <Switch sx={{ m: 1 }} checked={variable.published} onChange={(e) => updateVariablePublishing(variable.name, e.target.checked)} />
+    <Switch checked={variable.published} onChange={(e) => updateVariablePublishing(variable.name, e.target.checked)} />
   );
 }
 
@@ -202,7 +202,7 @@ export const UsersField: React.FC<{ variable: ContextVariable | Variable, onClos
     <>
       <Tooltip title={<FormattedMessage id='dialogs.variables.users.tooltip' />}>
         <Button variant='text' onClick={(e) => setAnchorEl(e.currentTarget)}>
-          <Typography fontWeight='bold' color='primary.main' variant='h4'>
+          <Typography fontWeight='bold' color='primary.main'>
             {users.length}
           </Typography>
         </Button>

--- a/frontend/dialob-composer-material/src/dialogs/FormOptionsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/FormOptionsDialog.tsx
@@ -107,7 +107,7 @@ const FormOptionsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
   }, [required, setMetadataValue]);
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md'>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
       <DialogTitle sx={{ fontWeight: 'bold', display: 'flex', justifyContent: 'space-between' }}>
         <FormattedMessage id='dialogs.form.options.title' />
         <Button variant='outlined' endIcon={<Help />}

--- a/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
@@ -145,7 +145,7 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
     <>
       <UploadValuesetDialog open={uploadDialogOpen} onClose={() => setUploadDialogOpen(false)}
         currentValueSet={currentValueSet} setCurrentValueSet={setCurrentValueSet} />
-      <Dialog open={dialogOpen} onClose={handleClose} fullWidth maxWidth='xl'>
+      <Dialog open={dialogOpen} onClose={handleClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
         <DialogTitle sx={{ display: 'flex', alignItems: 'center', fontWeight: 'bold' }}>
           <FormattedMessage id='dialogs.lists.global.title' />
           <Box flexGrow={1} />
@@ -201,14 +201,14 @@ const GlobalListsDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
                   <BorderedTable>
                     <TableHead>
                       <TableRow>
-                        <TableCell width='20%' align='center'>
-                          <IconButton onClick={addEntry}><Add color='success' /></IconButton>
-                          <IconButton onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
-                          <IconButton onClick={() => downloadValueSet(currentValueSet)}><Download /></IconButton>
+                        <TableCell width='15%' align='center'>
+                          <IconButton sx={{ p: 0.25 }} onClick={addEntry}><Add color='success' /></IconButton>
+                          <IconButton sx={{ p: 0.25 }} onClick={() => setUploadDialogOpen(true)}><Upload /></IconButton>
+                          <IconButton sx={{ p: 0.25 }} onClick={() => downloadValueSet(currentValueSet)}><Download /></IconButton>
                         </TableCell>
-                        <TableCell width='30%' sx={{ p: 1 }}><Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography></TableCell>
+                        <TableCell width='20%' sx={{ p: 0.5 }}><Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography></TableCell>
                         {formLanguages?.map(lang => (
-                          <TableCell key={lang} width={formLanguages ? `${50 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
+                          <TableCell key={lang} width={formLanguages ? `${65 / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
                             <Typography fontWeight='bold'>
                               <FormattedMessage id='dialogs.options.text' values={{ language: lang }} />
                             </Typography>

--- a/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
@@ -139,7 +139,6 @@ const ItemOptionsDialog: React.FC = () => {
               </Tooltip>
             } value='rules' />
             {isInputType && <Tab icon={<Tooltip placement='right' title={<FormattedMessage id='tooltips.validations' />}><Rule /></Tooltip>} value='validations' />}
-            {isInputType && <Tab icon={<Tooltip placement='right' title={<FormattedMessage id='tooltips.default' />}><EditNote /></Tooltip>} value='defaults' />}
             {canHaveChoices && <Tab icon={<Tooltip placement='right' title={<FormattedMessage id='tooltips.choices' />}><List /></Tooltip>} value='choices' />}
             <Tab icon={<Tooltip placement='right' title={<FormattedMessage id='tooltips.properties' />}><Dns /></Tooltip>} value='properties' />
           </Tabs>
@@ -148,7 +147,6 @@ const ItemOptionsDialog: React.FC = () => {
             {activeTab === 'description' && <Editors.Description />}
             {activeTab === 'rules' && <Editors.Rules />}
             {activeTab === 'validations' && <Editors.Validations />}
-            {activeTab === 'defaults' && <Editors.Defaults />}
             {activeTab === 'choices' && <Editors.Choice />}
             {activeTab === 'properties' && <Editors.Properties />}
           </Box>

--- a/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
@@ -99,7 +99,7 @@ const ItemOptionsDialog: React.FC = () => {
   }
 
   return (
-    <Dialog open={open} onClose={handleClose} fullWidth maxWidth='xl'>
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
       <DialogTitle sx={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
         {editMode ? <TextField value={id} autoFocus={editMode} onChange={(e) => setId(e.target.value)} error={idError}
           helperText={<FormattedMessage id='dialogs.change.id.tip' />} InputProps={{

--- a/frontend/dialob-composer-material/src/dialogs/PreviewDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/PreviewDialog.tsx
@@ -62,7 +62,7 @@ const PreviewDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ open,
   }
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md'>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
       <DialogTitle sx={{ fontWeight: 'bold' }}>
         <FormattedMessage id='dialogs.preview.title' />
       </DialogTitle>

--- a/frontend/dialob-composer-material/src/dialogs/TranslationDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/TranslationDialog.tsx
@@ -12,7 +12,7 @@ const TranslationDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ o
   const docsUrl = useDocs('translations');
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth='xl'>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontWeight: 'bold' }}>
         <FormattedMessage id='dialogs.translations.title' />
         <Button variant='outlined' endIcon={<Help />}

--- a/frontend/dialob-composer-material/src/dialogs/UploadValuesetDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/UploadValuesetDialog.tsx
@@ -109,7 +109,7 @@ const UploadValuesetDialog: React.FC<{
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md'>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
       <DialogTitle sx={{ fontWeight: 'bold', display: 'flex', justifyContent: 'space-between' }}>
         <FormattedMessage id='dialogs.upload.valueset.title' />
         <Button variant='outlined' endIcon={<Help />}

--- a/frontend/dialob-composer-material/src/dialogs/VariablesDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/VariablesDialog.tsx
@@ -28,7 +28,7 @@ const VariablesDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ ope
   }
 
   return (
-    <Dialog open={dialogOpen} onClose={onClose} fullWidth maxWidth='xl'>
+    <Dialog open={dialogOpen} onClose={onClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontWeight: 'bold' }}>
         <FormattedMessage id='dialogs.variables.title' />
         <Button variant='outlined' endIcon={<Help />}

--- a/frontend/dialob-composer-material/src/dialogs/VersioningDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/VersioningDialog.tsx
@@ -75,7 +75,7 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
   }
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth='lg'>
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='md' PaperProps={{ sx: { maxHeight: '60vh' } }}>
       <DialogTitle sx={{ fontWeight: 'bold', display: 'flex', justifyContent: 'space-between' }}>
         <FormattedMessage id='dialogs.versioning.title' />
         <Button variant='outlined' endIcon={<Help />}

--- a/frontend/dialob-composer-material/src/editor/types.ts
+++ b/frontend/dialob-composer-material/src/editor/types.ts
@@ -3,7 +3,7 @@ import { DialobItem } from "../dialob";
 export type ErrorSeverity = 'ERROR' | 'WARNING' | 'INFO' | 'FATAL';
 export type ComposerStatus = 'ERROR' | 'WARNING' | 'INFO' | 'FATAL' | 'OK';
 export type ConfirmationDialogType = 'duplicate' | 'delete';
-export type OptionsTabType = 'id' | 'label' | 'description' | 'rules' | 'validations' | 'choices' | 'defaults' | 'properties';
+export type OptionsTabType = 'id' | 'label' | 'description' | 'rules' | 'validations' | 'choices' | 'properties';
 export type VariableTabType = 'context' | 'expression';
 
 export type EditorError = {

--- a/frontend/dialob-composer-material/src/intl/en.ts
+++ b/frontend/dialob-composer-material/src/intl/en.ts
@@ -111,7 +111,7 @@ const en = {
   'dialogs.options.choices.divider': 'OR',
   'dialogs.options.properties.add': 'Add property',
   'dialogs.options.properties.add.short': 'Add',
-  'dialogs.options.default.set': 'Set default value',
+  'dialogs.options.default': 'Default value',
   'dialogs.options.preview': 'Preview',
 
   'dialogs.upload.valueset.title': 'Upload value set',

--- a/frontend/dialob-composer-material/src/items/ItemComponents.tsx
+++ b/frontend/dialob-composer-material/src/items/ItemComponents.tsx
@@ -175,7 +175,7 @@ export const Indicators: React.FC<{ item: DialobItem }> = ({ item }) => {
         </Tooltip>}
       {item.defaultValue &&
         <Tooltip placement='top' title={<FormattedMessage id='tooltips.default' />}>
-          < IconButton onClick={(e) => handleClick(e, 'defaults')}><EditNote fontSize='small' sx={{ color: 'info.light' }} /></IconButton>
+          < IconButton onClick={(e) => handleClick(e, 'rules')}><EditNote fontSize='small' sx={{ color: 'info.light' }} /></IconButton>
         </Tooltip>}
       {item.type === 'note' && item.activeWhen &&
         <Tooltip placement='top' title={<FormattedMessage id='tooltips.visibility' />}>


### PR DESCRIPTION
- resolves issues #250 and #253 
- dialogs are reduced to a smaller width and height, and tables shown in dialogs are adjusted accordingly
- in prop editing tab, prop table is only shown if props exist
- default value editor is moved under rules tab
- when editing labels, text boxes for all form languages are shown (no more adding individual language translations)