### PR TITLE
Fix copying items with global value sets

### DIFF
--- a/dialob-components/dialob-form-service/src/test/java/io/dialob/form/service/copy/FormItemCopierTest.java
+++ b/dialob-components/dialob-form-service/src/test/java/io/dialob/form/service/copy/FormItemCopierTest.java
@@ -98,8 +98,21 @@ public class FormItemCopierTest {
     assertTrue(form.getData().containsKey("question1"));
     assertTrue(form.getData().containsKey("question11"));
     assertEquals(form.getData().get("group1").getItems().indexOf("question1") + 1, form.getData().get("group1").getItems().indexOf("question11"));
-    assertEquals(2, form.getValueSets().size());
+    assertEquals(3, form.getValueSets().size());
     assertEquals("valueSet11", form.getData().get("question11").getValueSetId());
+  }
+
+  @Test
+  public void testQuestionCopyGvs() {
+    Form form = loadForm();
+    Pair<Form, List<FormValidationError>> resultPair = formItemCopier.copyFormItem(form, "question4");
+    form = resultPair.getLeft();
+    assertEquals(0, resultPair.getRight().size());
+    assertTrue(form.getData().containsKey("question4"));
+    assertTrue(form.getData().containsKey("question41"));
+    assertEquals(form.getData().get("group1").getItems().indexOf("question4") + 1, form.getData().get("group1").getItems().indexOf("question41"));
+    assertEquals(2, form.getValueSets().size());
+    assertEquals("valueSet2", form.getData().get("question41").getValueSetId());
   }
 
   @Test
@@ -111,7 +124,7 @@ public class FormItemCopierTest {
     assertTrue(form.getData().containsKey("group1"));
     assertTrue(form.getData().containsKey("group11"));
     assertEquals(form.getData().get("page1").getItems().indexOf("group1") + 1, form.getData().get("page1").getItems().indexOf("group11"));
-    assertEquals(2, form.getValueSets().size());
+    assertEquals(3, form.getValueSets().size());
     assertEquals("valueSet11", form.getData().get("question11").getValueSetId());
     assertThat(form.getData().get("group11").getItems(), contains("question11", "question21", "question31", "question41"));
     assertEquals("question11 = 'test'", form.getData().get("question21").getRequired());

--- a/dialob-components/dialob-form-service/src/test/resources/renamerTestForm.json
+++ b/dialob-components/dialob-form-service/src/test/resources/renamerTestForm.json
@@ -137,7 +137,7 @@
       "style": null,
       "activeWhen": "\"entry1\" in question1",
       "validations": [],
-      "valueSetId": null,
+      "valueSetId": "valueSet2",
       "options": {}
     }
 
@@ -149,7 +149,15 @@
     "label": "Test Form",
     "created": "2016-05-06T08:45:23.641Z",
     "lastSaved": "2016-05-06T08:47:39.921Z",
-    "valid": true
+    "valid": true,
+    "composer": {
+      "globalValueSets": [
+        {
+          "label": "gvs1",
+          "valueSetId": "valueSet2"
+        }
+      ]
+    }
   },
   "variables": [
     {
@@ -170,6 +178,23 @@
         {
           "id": "entry2",
           "when": "question1 = 'zz'",
+          "label": {
+            "en": "Entry label 2"
+          }
+        }
+      ]
+    },
+    {
+      "id": "valueSet2",
+      "entries": [
+        {
+          "id": "entry1",
+          "label": {
+            "en": "Entry label 1"
+          }
+        },
+        {
+          "id": "entry2",
           "label": {
             "en": "Entry label 2"
           }


### PR DESCRIPTION
- if an item has a global value set, the value set won't be copied anymore, the new item will just point to the same value set ID