### PR TITLE
Add dot as a valid character in tag names

### DIFF
--- a/dialob-config-parent/dialob-common/src/main/java/io/dialob/common/Constants.java
+++ b/dialob-config-parent/dialob-common/src/main/java/io/dialob/common/Constants.java
@@ -55,7 +55,7 @@ public final class Constants {
   public static final String VALID_FORM_ID_PATTERN = VALID_FORM_NAME_PATTERN;
   public static final Pattern VALID_FORM_ID_PATTERN_COMPILED = Pattern.compile(VALID_FORM_ID_PATTERN);
 
-  public static final String VALID_FORM_TAG_PATTERN = VALID_FORM_NAME_PATTERN;
+  public static final String VALID_FORM_TAG_PATTERN = "[\\p{Alnum}-_.]+";
   public static final Pattern VALID_FORM_TAG_PATTERN_COMPILED = Pattern.compile(VALID_FORM_TAG_PATTERN);
 
   public static final String QUESTIONNAIRE_ID_PATTERN = "[\\p{XDigit}-]{1,64}";

--- a/frontend/dialob-composer-material/src/dialogs/CreateTagDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/CreateTagDialog.tsx
@@ -31,7 +31,7 @@ const CreateTagDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ ope
   }, [open]);
 
   const handleCreate = () => {
-    const tagRegex = new RegExp(/^[0-9A-Za-z-_]+$/);
+    const tagRegex = new RegExp(/^[0-9A-Za-z-_.]+$/);
     if (!tagRegex.test(name)) {
       setError('dialogs.create.tag.error');
       return;


### PR DESCRIPTION
- modified frontend and backend validation regex to include `.` as a valid character in tag names