### PR TITLE
Group visualization improvements

### DIFF
--- a/frontend/dialob-composer-material/src/components/PageTabs.tsx
+++ b/frontend/dialob-composer-material/src/components/PageTabs.tsx
@@ -54,6 +54,7 @@ const PageTab: React.FC<{ item: DialobItem, onClick: (e: React.MouseEvent<HTMLEl
   const { editor } = useEditor();
   const isActive = item.id === editor.activePage?.id;
   const variant = isActive ? 'contained' : 'text';
+  const fontWeight = isActive ? 'bold' : 'normal';
   const [highlighted, setHighlighted] = React.useState<boolean>(false);
 
   React.useEffect(() => {
@@ -74,7 +75,7 @@ const PageTab: React.FC<{ item: DialobItem, onClick: (e: React.MouseEvent<HTMLEl
         color={highlighted ? 'info' : 'primary'}
         endIcon={<OptionsMenu item={item} isPage light={isActive} />}
       >
-        <Typography textTransform='none'>{getPageTabTitle(item, editor.activeFormLanguage)}</Typography>
+        <Typography textTransform='none' fontWeight={fontWeight}>{getPageTabTitle(item, editor.activeFormLanguage)}</Typography>
       </Button >
     </Box>
   );

--- a/frontend/dialob-composer-material/src/items/Group.tsx
+++ b/frontend/dialob-composer-material/src/items/Group.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { KeyboardArrowDown, KeyboardArrowRight } from '@mui/icons-material';
-import { Box, IconButton, Paper, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
+import { Box, IconButton, Paper, TableBody, TableCell, TableContainer, TableRow, alpha, styled, useTheme } from '@mui/material';
 import { Element } from 'react-scroll';
 import { DialobItem, DialobItems, useComposer } from '../dialob';
 import { AddItemMenu, ConversionMenu, IdField, Indicators, LabelField, OptionsMenu, StyledTable, VisibilityField } from './ItemComponents';
@@ -16,6 +16,13 @@ const createChildren = (item: DialobItem, items: DialobItems, itemConfig?: ItemC
     .map(itemId => items[itemId])
     .map(item => itemFactory(item, itemConfig));
 }
+
+const GroupPaper = styled(Paper)(({ theme }) => ({
+  border: 1,
+  borderColor: theme.palette.grey[500],
+  borderStyle: 'solid',
+  borderRadius: 4
+}));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
 const Group: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => {
@@ -44,7 +51,7 @@ const Group: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => 
 
   return (
     <Element name={item.id}>
-      <TableContainer component={Paper} sx={{ my: 2, ...highlightedSx }}>
+      <TableContainer component={GroupPaper} sx={{ my: 2, ...highlightedSx }}>
         <StyledTable errorBorderColor={errorBorderColor}>
           <TableBody>
             <TableRow>
@@ -54,7 +61,7 @@ const Group: React.FC<{ item: DialobItem, props?: any }> = ({ item, props }) => 
                 </IconButton>
               </TableCell>
               <TableCell width='20%'>
-                <IdField item={item} />
+                <IdField item={item} group />
               </TableCell>
               <TableCell>
                 <LabelField item={item} />

--- a/frontend/dialob-composer-material/src/items/ItemComponents.tsx
+++ b/frontend/dialob-composer-material/src/items/ItemComponents.tsx
@@ -73,8 +73,10 @@ const resolveTypeName = (type: string, itemTypeConfig: ItemTypeConfig): string =
   return type;
 }
 
-export const IdField: React.FC<{ item: DialobItem }> = ({ item }) => {
+export const IdField: React.FC<{ item: DialobItem, group?: true }> = ({ item, group }) => {
   const { setActiveItem, setItemOptionsActiveTab } = useEditor();
+  const variant = group ? 'body2' : 'body1';
+  const fontWeight = group ? 'bold' : undefined;
 
   const handleClick = () => {
     setActiveItem(item);
@@ -83,7 +85,7 @@ export const IdField: React.FC<{ item: DialobItem }> = ({ item }) => {
 
   return (
     <ItemHeaderButton variant='text' color='inherit' onClick={handleClick}>
-      <Typography>{item.id}</Typography>
+      <Typography variant={variant} fontWeight={fontWeight}>{item.id}</Typography>
     </ItemHeaderButton>
   );
 }
@@ -431,7 +433,7 @@ export const VisibilityField: React.FC<{ item: DialobItem }> = ({ item }) => {
       onClick={handleClick}
     >
       {item.activeWhen ?
-        <Typography fontFamily='monospace' textTransform='none'>
+        <Typography fontFamily='monospace' textTransform='none' fontSize={14}>
           {/* eslint-disable-next-line formatjs/no-literal-string-in-jsx */}
           {item.activeWhen.length > MAX_RULE_LENGTH ? item.activeWhen.substring(0, MAX_RULE_LENGTH) + '...' : item.activeWhen}
         </Typography> :


### PR DESCRIPTION
- group IDs changed to bold
- active page ID/name also changed to bold to match this
- group Paper container has an added border to distinguish from other types of items
- visibility field text font size reducing so as not to take attention away from the group ID

Before:
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/388b7d0f-975b-40b3-a430-5f6dbc90fff2" />


After:
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/0dc62cbb-8857-464d-9ec8-29528d9e00fd" />
