### PR TITLE
Unrestrict conversion types to allow customized item view types

### DIFF
--- a/frontend/dialob-composer-material/src/defaults/types.ts
+++ b/frontend/dialob-composer-material/src/defaults/types.ts
@@ -36,7 +36,7 @@ export interface CategoryItem {
   title: string,
   optionEditors?: OptionEditor[],
   propEditors?: PropEditorsType,
-  convertible?: DialobItemType[],
+  convertible?: string[],
   config: DialobItemTemplate
 }
 


### PR DESCRIPTION
Customization configurations can introduce new view types for items that need to be convertible, so the `convertible` attribute in `ItemTypeConfig` need not to be restricted to built-in types.

For example:
```typescript
 {
          title: 'Alert note',
          convertible: ['note', 'modalNote', 'imageNote', 'checkmarkNote', 'screenreader'],
 // . . . 
}
```

Please review if this won't cause any issues internally.