### PR TITLE
Fix item conversions

### DIFF
--- a/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage } from 'react-intl';
 import PropItem from '../PropItem';
 import { useBackend } from '../../backend/useBackend';
 import { DEFAULT_ITEMTYPE_CONFIG } from '../../defaults';
-import { findItemTypeConfig } from '../../utils/ConfigUtils';
+import { findItemPropEditor } from '../../utils/ConfigUtils';
 
 export type PropValue = string | string[] | boolean;
 
@@ -35,7 +35,7 @@ const PropertiesEditor: React.FC = () => {
   }
 
   const itemTypeConfig = config.itemTypes ?? DEFAULT_ITEMTYPE_CONFIG;
-  const propEditors = findItemTypeConfig(itemTypeConfig, item.type, item.view)?.propEditors;
+  const propEditors = findItemPropEditor(itemTypeConfig, item.view ?? item.type);
 
   const handleAddProp = () => {
     if (item) {

--- a/frontend/dialob-composer-material/src/items/ItemComponents.tsx
+++ b/frontend/dialob-composer-material/src/items/ItemComponents.tsx
@@ -12,7 +12,7 @@ import { OptionsTabType, useEditor } from "../editor";
 import { isPage } from "../utils/ItemUtils";
 import { scrollToAddedItem } from "../utils/ScrollUtils";
 import { useBackend } from "../backend/useBackend";
-import { findItemTypeConfig } from "../utils/ConfigUtils";
+import { findItemTypeConfig, findItemTypeConvertible } from "../utils/ConfigUtils";
 
 
 const MAX_LABEL_LENGTH_WITH_INDICATORS = 45;
@@ -47,12 +47,12 @@ export const StyledTable = styled(Table, {
 ));
 
 const getItemConversions = (item: DialobItem, itemTypeConfig: ItemTypeConfig): { text: string, value: DialobItemTemplate }[] => {
-  const thisItemType = findItemTypeConfig(itemTypeConfig, item.view ?? item.type);
+  const thisItemType = findItemTypeConfig(itemTypeConfig, item.type, item.view);
   const options: { text: string, value: DialobItemTemplate }[] = [];
 
   if (thisItemType && thisItemType.convertible) {
     thisItemType.convertible.forEach(t => {
-      const toItemType = findItemTypeConfig(itemTypeConfig, t);
+      const toItemType = findItemTypeConvertible(itemTypeConfig, t);
       if (toItemType) {
         options.push({
           text: toItemType.title,

--- a/frontend/dialob-composer-material/src/items/Note.tsx
+++ b/frontend/dialob-composer-material/src/items/Note.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Paper, Table, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
 import { Element } from 'react-scroll';
 import { DialobItem } from '../dialob';
-import { IdField, Indicators, NoteField, OptionsMenu } from './ItemComponents';
+import { ConversionMenu, IdField, Indicators, NoteField, OptionsMenu } from './ItemComponents';
 import { useEditor } from '../editor';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -37,6 +37,9 @@ const Note: React.FC<{ item: DialobItem } & Record<string, any>> = ({ item, ...p
               {hasIndicators && <TableCell width='15%'>
                 <Indicators item={item} />
               </TableCell>}
+              <TableCell width='15%' sx={centeredCellSx}>
+                <ConversionMenu item={item} />
+              </TableCell>
               <TableCell width='5%' sx={centeredCellSx}>
                 <OptionsMenu item={item} />
               </TableCell>

--- a/frontend/dialob-composer-material/src/utils/ConfigUtils.tsx
+++ b/frontend/dialob-composer-material/src/utils/ConfigUtils.tsx
@@ -10,3 +10,25 @@ export const findItemTypeConfig = (itemTypes: ItemTypeConfig, type: string, view
   }
   return null;
 }
+
+export const findItemTypeConvertible = (itemTypes: ItemTypeConfig, view: string) => {
+  for (const idx in itemTypes.categories) {
+    const c = itemTypes.categories[idx];
+    const resultConfig = c.items.find(v => v.config.type === view || v.config.view === view);
+    if (resultConfig) {
+      return resultConfig;
+    }
+  }
+  return null;
+}
+
+export const findItemPropEditor = (itemTypes: ItemTypeConfig, view: string) => {
+  for (const idx in itemTypes.categories) {
+    const c = itemTypes.categories[idx];
+    const resultConfig = c.items.find(v => v.config.type === view || v.config.view === view);
+    if (resultConfig && resultConfig.propEditors) {
+      return resultConfig.propEditors;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
- made note types convertible
- found and fixed an issue in the logic of retrieving conversion options (due to inconsistent use of config.type and config.view)