### PR TITLE
Fixed issues with duplicating items

### DIFF
--- a/frontend/dialob-composer-material/CHANGELOG.md
+++ b/frontend/dialob-composer-material/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @dialob/dialob-composer-material
 
+## 0.0.11
+
+### Patch Changes
+
+- fixed issues with duplicating items
+
 ## 0.0.10
 
 ### Patch Changes

--- a/frontend/dialob-composer-material/package.json
+++ b/frontend/dialob-composer-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialob/composer-material",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Dialob Form Authoring Tool",
   "private": false,
   "type": "module",

--- a/frontend/dialob-composer-material/src/dialogs/ConfirmationDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/ConfirmationDialog.tsx
@@ -12,7 +12,7 @@ const ConfirmationDialog: React.FC = () => {
   const { duplicateItem } = useBackend();
   const { editor, setConfirmationDialogType, setErrors } = useEditor();
   const type = editor.confirmationDialogType;
-  const activeItem = editor.activeItem;
+  const activeItem = editor.confirmationActiveItem;
   const [loading, setLoading] = React.useState(false);
 
   if (type === undefined || activeItem === undefined) {

--- a/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
@@ -29,6 +29,7 @@ const StyledButtonContainer = styled(Box)(({ theme }) => ({
 const SaveItemButton: React.FC = () => {
   const { form, applyItemChanges } = useComposer();
   const { savingState } = useSave();
+  const { editor } = useEditor();
 
   const hasChanges = React.useMemo(() => {
     return (savingState.item && (JSON.stringify(savingState.item) !== JSON.stringify(form.data[savingState.item.id]))) ||
@@ -38,7 +39,9 @@ const SaveItemButton: React.FC = () => {
   }, [savingState, form.data, form.valueSets, form.metadata.composer?.globalValueSets]);
 
   const handleSave = () => {
-    if (savingState.item) {
+    if (editor.activeItem && savingState.item && editor.activeItem.id !== savingState.item.id) {
+      console.warn('Active item ID has changed, not applying item changes to avoid inconsistencies.');
+    } else if (savingState.item) {
       applyItemChanges(savingState);
     }
   }

--- a/frontend/dialob-composer-material/src/editor/actions.ts
+++ b/frontend/dialob-composer-material/src/editor/actions.ts
@@ -12,3 +12,4 @@ export type EditorAction =
   | { type: 'setHighlightedItem', item?: DialobItem }
   | { type: 'setActiveList', listId?: string }
   | { type: 'setActiveVariableTab', tab?: VariableTabType }
+  | { type: 'setConfirmationActiveItem', item?: DialobItem }

--- a/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
+++ b/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
@@ -46,6 +46,10 @@ export const useEditor = () => {
     dispatch({ type: 'setActiveVariableTab', tab });
   }
 
+  const setConfirmationActiveItem = (item?: DialobItem): void => {
+    dispatch({ type: 'setConfirmationActiveItem', item });
+  }
+
   return {
     editor: state,
     setActivePage,
@@ -58,5 +62,6 @@ export const useEditor = () => {
     setHighlightedItem,
     setActiveList,
     setActiveVariableTab,
+    setConfirmationActiveItem,
   };
 }

--- a/frontend/dialob-composer-material/src/editor/reducer.ts
+++ b/frontend/dialob-composer-material/src/editor/reducer.ts
@@ -43,6 +43,10 @@ const setActiveVariableTab = (state: EditorState, tab?: VariableTabType): void =
   state.activeVariableTab = tab;
 }
 
+const setConfirmationActiveItem = (state: EditorState, item?: DialobItem): void => {
+  state.confirmationActiveItem = item;
+}
+
 export const editorReducer = (state: EditorState, action: EditorAction): EditorState => {
   const newState = produce(state, state => {
     if (action.type === 'setActivePage') {
@@ -65,6 +69,8 @@ export const editorReducer = (state: EditorState, action: EditorAction): EditorS
       setActiveList(state, action.listId);
     } else if (action.type === 'setActiveVariableTab') {
       setActiveVariableTab(state, action.tab);
+    } else if (action.type === 'setConfirmationActiveItem') {
+      setConfirmationActiveItem(state, action.item);
     }
   });
   return newState;

--- a/frontend/dialob-composer-material/src/editor/types.ts
+++ b/frontend/dialob-composer-material/src/editor/types.ts
@@ -22,6 +22,7 @@ export type EditorState = {
   activeFormLanguage: string;
   errors: EditorError[];
   activeItem?: DialobItem;
+  confirmationActiveItem?: DialobItem;
   confirmationDialogType?: ConfirmationDialogType;
   itemOptionsActiveTab?: OptionsTabType;
   highlightedItem?: DialobItem;

--- a/frontend/dialob-composer-material/src/items/ItemComponents.tsx
+++ b/frontend/dialob-composer-material/src/items/ItemComponents.tsx
@@ -242,7 +242,7 @@ export const ConversionMenu: React.FC<{ item?: DialobItem, inDialog?: boolean }>
 export const OptionsMenu: React.FC<{ item: DialobItem, isPage?: boolean, light?: boolean }> = ({ item, isPage, light }) => {
   const { form, addItem } = useComposer();
   const { config } = useBackend();
-  const { setConfirmationDialogType, setActiveItem, setItemOptionsActiveTab, setHighlightedItem } = useEditor();
+  const { setConfirmationDialogType, setActiveItem, setConfirmationActiveItem, setItemOptionsActiveTab, setHighlightedItem } = useEditor();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [categoriesAnchorEl, setCategoriesAnchorEl] = React.useState<null | HTMLElement>(null);
   const [itemsAnchorEl, setItemsAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -292,14 +292,14 @@ export const OptionsMenu: React.FC<{ item: DialobItem, isPage?: boolean, light?:
   const handleDelete = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     handleClose(e, 1);
-    setActiveItem(item);
+    setConfirmationActiveItem(item);
     setConfirmationDialogType('delete');
   }
 
   const handleDuplicate = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     handleClose(e, 1);
-    setActiveItem(item);
+    setConfirmationActiveItem(item);
     setConfirmationDialogType('duplicate');
   }
 


### PR DESCRIPTION
- issue was in `editor.activeItem` state being used incorrectly in two places for different purposes, which led to an early render and incorrect change in `savingState`  
- so when saving a duplicate item, the `savingState` was older and led to inconsistencies when saving, like editing the state of the previously active item, resulting in unpredictable behavior when lists are also modified
- logic is now correctly separated using `editor.confirmationActiveItem` for setting active item in confirmation dialogs, like the one for confirming duplication
- additionally, there is now a check to prevent an inconsistent save from persisting (`editor.activeItem.id !== savingState.item.id`)
- changeset created for releasing version `0.0.11`