### PR TITLE
New Markdown editor

### DIFF
--- a/frontend/dialob-composer-material/README.md
+++ b/frontend/dialob-composer-material/README.md
@@ -102,3 +102,11 @@ pnpm run preview
 Starts preview server for built application from `/dist` (No hot-reload!). Run `pnpm build` first to build the package
 
 ---
+
+### Customixing Markdown components
+
+You can customize how markdown is rendered by passing custom components to the `Markdown` component from `react-markdown`. 
+  
+List of available components can be found in [`src/defaults/markdown.tsx`](https://github.com/dialob/dialob-parent/blob/dev/frontend/dialob-composer-material/src/defaults/markdown.tsx). See also [`src/components/editors/LocalizedStringEditor.tsx`](https://github.com/dialob/dialob-parent/blob/dev/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx) for an example of how to use custom components. To support table rendering, you also need to include the `remark-gfm` plugin.
+  
+The same components can be used on the filling side as well, so that the markdown looks the same when editing and when filling the form.

--- a/frontend/dialob-composer-material/package.json
+++ b/frontend/dialob-composer-material/package.json
@@ -29,9 +29,12 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.16.0",
-    "@codemirror/lang-javascript": "^6.2.1",
-    "@codemirror/language": "^6.10.1",
-    "@codemirror/lint": "^6.7.1",
+    "@codemirror/lang-javascript": "^6.2.4",
+    "@codemirror/lang-markdown": "^6.3.4",
+    "@codemirror/language": "^6.11.3",
+    "@codemirror/lint": "^6.8.5",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.38.3",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -48,7 +51,8 @@
     "react-dom": "^18.2.0",
     "react-intl": "^7.1.11",
     "react-markdown": "^10.1.0",
-    "react-scroll": "^1.9.0"
+    "react-scroll": "^1.9.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",

--- a/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Markdown from 'react-markdown';
-import { Button, Typography, Box, TextareaAutosize } from '@mui/material';
+import { Button, Typography, Box } from '@mui/material';
 import { Visibility } from '@mui/icons-material';
 import { FormattedMessage } from 'react-intl';
 import { useComposer } from '../../dialob';
@@ -9,6 +9,8 @@ import { IndexedRule } from './types';
 import { getLanguageName } from '../../utils/TranslationUtils';
 import { LocalizedString } from '../../types';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
+import { MarkdownEditor } from './MarkdownEditor';
+import remarkGfm from 'remark-gfm';
 
 
 const LocalizedStringEditor: React.FC<{
@@ -56,11 +58,10 @@ const LocalizedStringEditor: React.FC<{
             <Box display='flex' alignItems='center'>
               <Typography color='text.hint'>{getLanguageName(language)}</Typography>
             </Box>
-            {preview ?
-              <Box sx={{ border: 1, borderRadius: 0.5, borderColor: 'text.secondary' }}>
-                <Markdown skipHtml components={markdownComponents}>{localizedText}</Markdown>
-              </Box > :
-              <TextareaAutosize style={{ width: '100%', maxWidth: '100%' }} minRows={5} value={localizedText} onChange={(e) => handleUpdate(e.target.value, language)} />}
+            <Box sx={{ border: 1, borderRadius: 1, borderColor: 'divider', my: 1 }}>
+              {preview ? <Markdown components={markdownComponents} remarkPlugins={[remarkGfm]}>{localizedText}</Markdown> :
+              <MarkdownEditor value={localizedText} setValue={handleUpdate} language={language} />}
+            </Box>
           </Box>
         );
       })}

--- a/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
@@ -1,0 +1,450 @@
+import React, { useRef, useState, useCallback } from "react";
+import { Menu, MenuItem, ListItemText, ListItemIcon, Box, useTheme } from "@mui/material";
+import { ArrowRight, FormatColorText, FormatListBulleted, MenuOpen, Title } from "@mui/icons-material";
+import CodeMirror from '@uiw/react-codemirror';
+import { markdown } from '@codemirror/lang-markdown';
+import { EditorView } from '@codemirror/view';
+import Markdown from 'react-markdown';
+import { markdownComponents } from "../../defaults/markdown";
+
+type MarkdownAction = { type: "wrap"; before: string; after: string } | { type: "insert"; text: string };
+
+export const MarkdownEditor: React.FC<{ value: string, setValue: (value: string, language: string) => void, language: string }> = ({ value, setValue, language }) => {
+  const theme = useTheme();
+  const editorRef = useRef<any>(null);
+  const [anchor, setAnchor] = useState<{ mouseX: number; mouseY: number } | null>(null);
+  const [submenu, setSubmenu] = useState<null | string>(null);
+  const [thirdLevelMenu, setThirdLevelMenu] = useState<null | string>(null);
+  const [submenuAnchor, setSubmenuAnchor] = useState<{ mouseX: number; mouseY: number } | null>(null);
+  const [thirdLevelAnchor, setThirdLevelAnchor] = useState<{ mouseX: number; mouseY: number } | null>(null);
+
+  const applyMarkdown = useCallback((action: MarkdownAction) => {
+    const view = editorRef.current?.view;
+    if (!view) return;
+    
+    let start = view.state.selection.main.from;
+    let end = view.state.selection.main.to;
+    let alreadyWrapped = false;
+    const text = value || '';
+
+    // Auto-expand word selection if no text is selected
+    if (action.type === "wrap" && start === end) {
+      // Find word boundaries around cursor using Unicode-aware pattern
+      const wordPattern = /[\p{L}\p{M}\p{N}\p{Pc}]/u;
+      
+      let left = start;
+      while (left > 0 && wordPattern.test(text[left - 1])) left--;
+
+      let right = end;
+      while (right < text.length && wordPattern.test(text[right])) right++;
+
+      const foundWord = left < right && wordPattern.test(text.slice(left, right));
+      const cursorInWord = start >= left && start <= right;
+      
+      if (foundWord && cursorInWord) {
+        // Check if the word is already wrapped with the same markup
+        const { before, after } = action;
+        const beforeLeft = Math.max(0, left - before.length);
+        const afterRight = Math.min(text.length, right + after.length);
+        
+        if (text.slice(beforeLeft, left) === before && text.slice(right, afterRight) === after) {
+          // Word is already wrapped, expand selection to include the markup for removal
+          alreadyWrapped = true;
+          start = beforeLeft;
+          end = afterRight;
+        } else {
+          // Word is not wrapped, select just the word for wrapping
+          start = left;
+          end = right;
+        }
+      }
+    }
+
+    const beforeText = text.slice(0, start);
+    const selected = text.slice(start, end);
+    const afterText = text.slice(end);
+
+    let newValue = text;
+    let newCursor = start;
+
+    if (action.type === "wrap") {
+      const { before, after } = action;
+
+      let wrappedText;
+      if (alreadyWrapped) {
+        wrappedText = selected.slice(before.length, selected.length - after.length);
+      } else {
+        wrappedText = before + (selected || "text") + after;
+      }
+      newValue = beforeText + wrappedText + afterText;
+      newCursor = start + wrappedText.length;
+
+    } else if (action.type === "insert") {
+      newValue = beforeText + action.text + afterText;
+      newCursor = start + action.text.length;
+    }
+
+    setValue(newValue, language);
+
+    requestAnimationFrame(() => {
+      if (action.type === "wrap") {
+        const { before } = action;
+        let cursorPos;
+        
+        if (selected === "" || (selected === "text" && action.type === "wrap")) {
+          // No real text was selected or placeholder was used, position cursor between the markup
+          cursorPos = start + before.length;
+        } else {
+          // Real text was selected, position cursor at the end of text, before markup
+          cursorPos = newCursor - (alreadyWrapped ? 0 : before.length)
+        }
+
+        view.dispatch({
+          selection: { anchor: cursorPos, head: cursorPos }
+        });
+      
+      } else {
+        // For insert actions, position cursor at the end
+        view.dispatch({
+          selection: { anchor: newCursor, head: newCursor }
+        });
+      }
+      view.focus();
+    });
+
+    handleClose();
+  }, [value, setValue, language]);
+
+  const insertOnNewLine = useCallback((text: string) => {
+    const view = editorRef.current?.view;
+    if (!view) return;
+
+    const start = view.state.selection.main.from;
+    const currentText = value || '';
+    
+    // Check if newlines need to be added
+    const beforeCursor = currentText.slice(0, start);
+    const afterCursor = currentText.slice(start);
+    
+    let prefix = "";
+    let suffix = "";
+    
+    // Add newline before if not at start of line
+    if (beforeCursor.length > 0 && !beforeCursor.endsWith('\n\n')) {
+      prefix = "\n\n";
+    }
+    
+    // Add newline after if there's content after and it doesn't start with newline
+    if (afterCursor.length > 0 && !afterCursor.startsWith('\n\n')) {
+      suffix = "\n\n";
+    }
+    
+    const fullText = prefix + text + suffix;
+    applyMarkdown({ type: "insert", text: fullText });
+  }, [value, applyMarkdown]);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent) => {
+    const isCtrl = event.ctrlKey;
+
+    // Bold shortcut
+    if (isCtrl && event.key === 'b') {
+      event.preventDefault();
+      applyMarkdown({ type: "wrap", before: "**", after: "**" });
+      return;
+    }
+    
+    // Italic shortcut
+    if (isCtrl && event.key === 'i') {
+      event.preventDefault();
+      applyMarkdown({ type: "wrap", before: "*", after: "*" });
+      return;
+    }
+    
+    // Code formatting shortcut
+    if (isCtrl && event.key === 'e') {
+      event.preventDefault();
+      applyMarkdown({ type: "wrap", before: "`", after: "`" });
+      return;
+    }
+    
+    // Link shortcut
+    if (isCtrl && event.key === 'k') {
+      event.preventDefault();
+      applyMarkdown({ type: "wrap", before: "[", after: "](url)" });
+      return;
+    }
+    
+    // Code block shortcut
+    if (isCtrl && event.shiftKey && event.key === 'C') {
+      event.preventDefault();
+      insertOnNewLine("```\ncode block\n```");
+      return;
+    }
+    
+    // Bullet list shortcut
+    if (isCtrl && event.shiftKey && event.key === 'L') {
+      event.preventDefault();
+      insertOnNewLine("- ");
+      return;
+    }
+    
+    // Numbered list shortcut
+    if (isCtrl && event.altKey && event.key === 'l') {
+      event.preventDefault();
+      insertOnNewLine("1. ");
+      return;
+    }
+    
+    // Heading shortcuts (Ctrl+1 through Ctrl+6)
+    if (isCtrl && /^[1-6]$/.test(event.key)) {
+      event.preventDefault();
+      const level = parseInt(event.key);
+      insertOnNewLine("#".repeat(level) + " ");
+      return;
+    }
+    
+    // Horizontal rule shortcut
+    if (isCtrl && event.key === '-') {
+      event.preventDefault();
+      insertOnNewLine("---");
+      return;
+    }
+    
+    // Table shortcut
+    if (isCtrl && event.key === 't') {
+      event.preventDefault();
+      insertOnNewLine("| Header 1 | Header 2 | Header 3 |\n|----------|----------|----------|\n| Row 1    | Data     | Data     |\n| Row 2    | Data     | Data     |");
+      return;
+    }
+  }, [applyMarkdown, insertOnNewLine, value, setValue, language]);
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    event.preventDefault();
+    const view = editorRef.current?.view;
+    if (view) {
+      const start = view.state.selection.main.from;
+      const end = view.state.selection.main.to;
+
+      requestAnimationFrame(() => {
+        view.dispatch({
+          selection: { anchor: start, head: end }
+        });
+        view.focus();
+      });
+    }
+    setAnchor({ mouseX: event.clientX + 2, mouseY: event.clientY - 6 });
+    setSubmenu(null);
+  };
+
+  const handleClose = () => {
+    setAnchor(null);
+    setSubmenu(null);
+    setThirdLevelMenu(null);
+    setSubmenuAnchor(null);
+    setThirdLevelAnchor(null);
+  };
+
+  return (
+    <Box sx={{ my: 1 }}>
+      <CodeMirror
+        ref={editorRef}
+        value={value}
+        onChange={(val: string) => setValue(val || '', language)}
+        extensions={[
+          markdown({
+            completeHTMLTags: false
+          }),
+          EditorView.lineWrapping,
+          EditorView.theme({
+            '&': {
+              fontSize: theme.typography.body1.fontSize || '15px',
+            },
+            '.cm-activeLine': {
+              backgroundColor: 'transparent',
+            },
+            '.cm-activeLineGutter': {
+              backgroundColor: 'transparent',
+            }
+          })
+        ]}
+        basicSetup={{
+          lineNumbers: false,
+          foldGutter: false,
+          dropCursor: false,
+          allowMultipleSelections: false,
+          indentOnInput: true,
+          bracketMatching: true,
+          closeBrackets: true,
+          autocompletion: false,
+          highlightSelectionMatches: false,
+          searchKeymap: false,
+        }}
+        onContextMenu={handleContextMenu}
+        onKeyDown={handleKeyDown}
+      />
+
+      <Menu
+        open={anchor !== null}
+        onClose={handleClose}
+        anchorReference="anchorPosition"
+        anchorPosition={
+          anchor ? { top: anchor.mouseY, left: anchor.mouseX } : undefined
+        }
+        disableAutoFocus
+      >
+        <MenuItem 
+          onClick={() => setSubmenu("format")}
+          onMouseEnter={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setSubmenuAnchor({ mouseX: rect.right, mouseY: rect.top });
+          }}
+        >
+          <ListItemIcon>
+            <FormatColorText />
+          </ListItemIcon>
+          <ListItemText disableTypography>Format</ListItemText>
+          <ListItemIcon>
+            <ArrowRight />
+          </ListItemIcon>
+        </MenuItem>
+        <MenuItem 
+          onClick={() => setSubmenu("list")}
+          onMouseEnter={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setSubmenuAnchor({ mouseX: rect.right, mouseY: rect.top });
+          }}
+        >
+          <ListItemIcon>
+            <FormatListBulleted />
+          </ListItemIcon>
+          <ListItemText disableTypography>List</ListItemText>
+          <ListItemIcon>
+            <ArrowRight />
+          </ListItemIcon>
+        </MenuItem>
+        <MenuItem 
+          onClick={() => setSubmenu("paragraph")}
+          onMouseEnter={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setSubmenuAnchor({ mouseX: rect.right, mouseY: rect.top });
+          }}
+        >
+          <ListItemIcon>
+            <Title />
+          </ListItemIcon>
+          <ListItemText disableTypography>Paragraph</ListItemText>
+          <ListItemIcon>
+            <ArrowRight />
+          </ListItemIcon>
+        </MenuItem>
+        <MenuItem 
+          onClick={() => setSubmenu("insert")}
+          onMouseEnter={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setSubmenuAnchor({ mouseX: rect.right, mouseY: rect.top });
+          }}
+        >
+          <ListItemIcon>
+            <MenuOpen />
+          </ListItemIcon>
+          <ListItemText disableTypography>Insert</ListItemText>
+          <ListItemIcon>
+            <ArrowRight />
+          </ListItemIcon>
+        </MenuItem>
+      </Menu>
+
+      <Menu
+        open={submenu === "format"}
+        onClose={() => setSubmenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={submenuAnchor ? { top: submenuAnchor.mouseY, left: submenuAnchor.mouseX } : undefined}
+        disableAutoFocus
+      >
+        <MenuItem onClick={() => applyMarkdown({ type: "wrap", before: "**", after: "**" })}>Bold</MenuItem>
+        <MenuItem onClick={() => applyMarkdown({ type: "wrap", before: "*", after: "*" })}>Italic</MenuItem>
+        <MenuItem onClick={() => applyMarkdown({ type: "wrap", before: "`", after: "`" })}>Code</MenuItem>
+      </Menu>
+
+      <Menu
+        open={submenu === "list"}
+        onClose={() => setSubmenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={submenuAnchor ? { top: submenuAnchor.mouseY, left: submenuAnchor.mouseX } : undefined}
+        disableAutoFocus
+      >
+        <MenuItem onClick={() => insertOnNewLine("- ")}>Bullet List</MenuItem>
+        <MenuItem onClick={() => insertOnNewLine("1. ")}>Numbered List</MenuItem>
+      </Menu>
+
+      <Menu
+        open={submenu === "paragraph"}
+        onClose={() => setSubmenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={submenuAnchor ? { top: submenuAnchor.mouseY, left: submenuAnchor.mouseX } : undefined}
+        disableAutoFocus
+      >
+        {[1, 2, 3, 4, 5, 6].map((lvl) => (
+          <MenuItem
+            key={lvl}
+            onClick={() => insertOnNewLine("#".repeat(lvl) + " ")}
+            sx={{ py: 1 }}
+          >
+            <Markdown components={markdownComponents}>
+              {"#".repeat(lvl) + " Heading " + lvl}
+            </Markdown>
+          </MenuItem>
+        ))}
+        <MenuItem onClick={() => applyMarkdown({ type: "insert", text: "text" })}>Body</MenuItem>
+      </Menu>
+
+      <Menu
+        open={submenu === "insert"}
+        onClose={() => setSubmenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={submenuAnchor ? { top: submenuAnchor.mouseY, left: submenuAnchor.mouseX } : undefined}
+        disableAutoFocus
+      >
+        <MenuItem
+          onClick={() => applyMarkdown({ type: "wrap", before: "[", after: "](url)" })}
+        >
+          Link
+        </MenuItem>
+        <MenuItem onClick={() => insertOnNewLine("```\ncode block\n```")}>
+          Code Block
+        </MenuItem>
+        <MenuItem onClick={() => insertOnNewLine("---")}>
+          Horizontal Divider
+        </MenuItem>
+        <MenuItem onClick={() => insertOnNewLine("| Header 1 | Header 2 | Header 3 |\n|----------|----------|----------|\n| Row 1    | Data     | Data     |\n| Row 2    | Data     | Data     |")}>          
+          Table
+        </MenuItem>
+        <MenuItem 
+          onClick={() => setThirdLevelMenu("callouts")}
+          onMouseEnter={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            setThirdLevelAnchor({ mouseX: rect.right, mouseY: rect.top });
+          }}
+        >
+          <ListItemText disableTypography>Callouts</ListItemText>
+          <ListItemIcon>
+            <ArrowRight />
+          </ListItemIcon>
+        </MenuItem>
+      </Menu>
+
+      <Menu
+        open={thirdLevelMenu === "callouts"}
+        onClose={() => setThirdLevelMenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={thirdLevelAnchor ? { top: thirdLevelAnchor.mouseY, left: thirdLevelAnchor.mouseX } : undefined}
+        disableAutoFocus
+      >
+        <MenuItem onClick={() => insertOnNewLine("> [!NOTE]\n> This is a note callout.")}>Note</MenuItem>
+        <MenuItem onClick={() => insertOnNewLine("> [!TIP]\n> This is a tip callout.")}>Tip</MenuItem>
+        <MenuItem onClick={() => insertOnNewLine("> [!WARNING]\n> This is a warning callout.")}>Warning</MenuItem>
+        <MenuItem onClick={() => insertOnNewLine("> [!ERROR]\n> This is an error callout.")}>Error</MenuItem>
+      </Menu>
+    </Box>
+  );
+};

--- a/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
@@ -327,6 +327,9 @@ export const MarkdownEditor: React.FC<{ value: string, setValue: (value: string,
             key={item.id}
             onClick={() => setMenuState(prev => ({ ...prev, submenu: item.id, thirdLevelMenu: null }))}
             onMouseEnter={(e) => handleMouseEnter(e, 'submenu')}
+            sx={{
+              backgroundColor: menuState.submenu === item.id ? theme.palette.action.hover : 'inherit'
+            }}
           >
             <ListItemIcon>
               <item.icon />
@@ -422,6 +425,7 @@ export const MarkdownEditor: React.FC<{ value: string, setValue: (value: string,
         <MenuItem 
           onClick={() => setMenuState(prev => ({ ...prev, thirdLevelMenu: "callouts" }))}
           onMouseEnter={(e) => handleMouseEnter(e, 'thirdLevel')}
+          sx={{ backgroundColor: menuState.thirdLevelMenu === "callouts" ? theme.palette.action.hover : 'inherit' }}
         >
           <ListItemText disableTypography>
             <FormattedMessage id="markdownEditor.callouts" />

--- a/frontend/dialob-composer-material/src/defaults/markdown.tsx
+++ b/frontend/dialob-composer-material/src/defaults/markdown.tsx
@@ -1,4 +1,5 @@
-import { Box, Divider, Link, Typography } from '@mui/material';
+import React from 'react';
+import { Box, Divider, Link, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Alert } from '@mui/material';
 
 export const markdownComponents: object = {
   h1: ({ children }: { children: React.ReactNode }) => <Typography variant='h1'>{children}</Typography>,
@@ -10,5 +11,98 @@ export const markdownComponents: object = {
   hr: () => <Divider />,
   p: ({ children }: { children: React.ReactNode }) => <Typography variant='body1' paragraph>{children}</Typography>,
   'a': (props: { href: string, children: React.ReactNode }) => <Link href={props.href}>{props.children}</Link>,
-  'img': (props: { alt: string, src: string }) => <Box component="img" alt={props.alt} src={props.src} maxWidth={600} width="100%" padding="8px 0px" />
+  'img': (props: { alt: string, src: string }) => <Box component="img" alt={props.alt} src={props.src} maxWidth={600} width="100%" padding="8px 0px" />,
+  table: ({ children }: { children: React.ReactNode }) => (
+    <TableContainer component={Paper} sx={{ my: 2 }}>
+      <Table children={children} />
+    </TableContainer>
+  ),
+  thead: ({ children }: { children: React.ReactNode }) => <TableHead children={children} />,
+  tbody: ({ children }: { children: React.ReactNode }) => <TableBody children={children} />,
+  tr: ({ children }: { children: React.ReactNode }) => <TableRow children={children} />,
+  th: ({ children }: { children: React.ReactNode }) => (
+    <TableCell children={children} sx={{ fontWeight: "bold", backgroundColor: "grey.100" }} />
+  ),
+  td: ({ children }: { children: React.ReactNode }) => <TableCell children={children} />,
+  pre: ({ children }: { children: React.ReactNode }) => (
+    <Box
+      component="pre"
+      sx={{
+        backgroundColor: "grey.800",
+        color: "grey.100",
+        p: 1,
+        borderRadius: 2,
+        overflowX: "auto",
+        m: 2,
+        fontFamily: "monospace",
+        'code': {
+          backgroundColor: 'inherit'
+        }
+      }}
+    >
+      {children}
+    </Box>
+  ),
+  code: ({ children }: { children: React.ReactNode }) => (
+    <Box
+      component="code"
+      sx={{
+        fontFamily: "monospace",
+        px: 0.5,
+        borderRadius: 1,
+        color: "white",
+        backgroundColor: "grey.600"
+      }}
+    >
+      {children}
+    </Box>
+  ),
+  blockquote: ({ children }: { children: React.ReactNode }) => {
+    const rawText = React.Children.toArray(children)
+      .map((child) => {
+        if (typeof child === "string") return child;
+        if (React.isValidElement(child)) return React.Children.toArray(child.props.children).join("");
+        return "";
+      })
+      .join("")
+      .trim();
+
+    // Match patterns like [!NOTE], [!TIP], [!WARNING], [!ERROR]
+    const match = rawText.match(/^\[!(\w+)\]\s*(.*)/);
+
+    if (match) {
+      const [, type, body] = match;
+
+      // Map callout types to MUI severities
+      const severityMap: Record<string, "info" | "success" | "warning" | "error"> = {
+        NOTE: "info",
+        TIP: "success",
+        WARNING: "warning",
+        ERROR: "error",
+      };
+
+      return (
+        <Alert severity={severityMap[type] || "info"} sx={{ m: 2 }}>
+          {body}
+        </Alert>
+      );
+    }
+
+    // Default blockquote
+    return (
+      <Box
+        component="blockquote"
+        sx={{
+          borderLeft: 1,
+          borderColor: "grey.400",
+          pl: 2,
+          my: 2,
+          color: "grey.700",
+          fontStyle: "italic",
+        }}
+      >
+        {children}
+      </Box>
+    );
+  },
 }

--- a/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
@@ -101,7 +101,7 @@ const SaveIdButton: React.FC<{
 }
 
 const ItemOptionsDialog: React.FC = () => {
-  const { editor, setActiveItem, setItemOptionsActiveTab, setConfirmationDialogType } = useEditor();
+  const { editor, setActiveItem, setItemOptionsActiveTab, setConfirmationDialogType, setMarkdownHelpDialogOpen } = useEditor();
   const { form } = useComposer();
   const { config } = useBackend();
   const item = editor.activeItem;
@@ -148,6 +148,14 @@ const ItemOptionsDialog: React.FC = () => {
     setId(item?.id || '');
   }
 
+  const handleOpenHelp = () => {
+    if (activeTab === 'label' || activeTab === 'description') {
+      setMarkdownHelpDialogOpen(true);
+      return;
+    }
+    window.open(docsUrl, "_blank");
+  }
+
   if (!item) {
     return null;
   }
@@ -175,8 +183,7 @@ const ItemOptionsDialog: React.FC = () => {
             </Button>}
           <Box flexGrow={1} />
           <StyledButtonContainer>
-            <Button variant='outlined' endIcon={<Help />}
-              onClick={() => window.open(docsUrl, "_blank")}>
+            <Button variant='outlined' endIcon={<Help />} onClick={handleOpenHelp}>
               <FormattedMessage id='buttons.help' />
             </Button>
             <ConversionMenu inDialog />

--- a/frontend/dialob-composer-material/src/dialogs/MARKDOWN_EDITOR.md
+++ b/frontend/dialob-composer-material/src/dialogs/MARKDOWN_EDITOR.md
@@ -1,0 +1,136 @@
+# MarkdownEditor Documentation
+
+---
+
+The MarkdownEditor is a powerful, feature-rich markdown editing component built with CodeMirror that provides real-time syntax highlighting and intelligent editing features.
+
+## Features
+
+---
+
+### **Syntax Highlighting**
+- Real-time markdown syntax highlighting
+- Support for all standard markdown elements
+- Clean, readable color scheme
+
+### **Smart Text Selection**
+- Auto-expands to word boundaries when no text is selected
+- Precise formatting application to selected text
+- Intelligent cursor positioning after operations
+
+### **Context Menus**
+- Right-click context menus for formatting options
+- Hierarchical menu structure for organized access
+- Visual icons for each formatting type
+
+### **List Management**
+- List continuation on Enter
+- Smart indentation with Tab/Shift+Tab
+- Support for both bullet and numbered lists
+
+### **Block Element Insertion**
+- **New line placement**: Headings, lists, code blocks, and horizontal rules are automatically placed on new lines
+- **Smart spacing**: Adds appropriate line breaks before and after
+
+### Support for Tables and Callouts
+- Using custom MUI rendering to show tables and callouts
+- Support for multiple callouts - note (info), tip (success), error, warning
+
+## Shortcuts
+
+---
+
+### **Text Formatting**
+| Menu Shortcut | Keyboard Shortcut | Action | Result |
+|---------------|------------------|--------|---------|
+| Format → Bold | `Ctrl+B` | **Bold** | `**text**` |
+| Format → Italic | `Ctrl+I` | *Italic* | `*text*` |
+| Format → Code | `Ctrl+E` | `Code` | `` `text` `` |
+
+---
+
+### **Lists**
+| Menu Shortcut | Keyboard Shortcut | Action | Result |
+|---------------|------------------|--------|---------|
+| List → Bullet List | `Ctrl+Shift+L` | Bullet List | `- item` |
+| List → Numbered List | `Ctrl+Alt+L` | Numbered List | `1. item` |
+| — | `Tab` | Indent List Item | Add 2 spaces |
+| — | `Shift+Tab` | Unindent List Item | Remove 2 spaces |
+
+---
+
+### **Headings**
+| Menu Shortcut | Keyboard Shortcut | Action | Result |
+|---------------|------------------|--------|---------|
+| Paragraph → Heading 1 | `Ctrl+1` | Heading 1 | `# text` |
+| Paragraph → Heading 2 | `Ctrl+2` | Heading 2 | `## text` |
+| Paragraph → Heading 3 | `Ctrl+3` | Heading 3 | `### text` |
+| Paragraph → Heading 4 | `Ctrl+4` | Heading 4 | `#### text` |
+| Paragraph → Heading 5 | `Ctrl+5` | Heading 5 | `##### text` |
+| Paragraph → Heading 6 | `Ctrl+6` | Heading 6 | `###### text` |
+
+---
+
+### **Insert & Undo**
+| Menu Shortcut | Keyboard Shortcut | Action | Result |
+|---------------|------------------|--------|---------|
+| Insert → Link | `Ctrl+K` | Link | `[text](url)` |
+| Insert → Code Block | `Ctrl+Shift+C` | Code Block | ```\ncode block\n``` |
+| Insert → Horizontal Divider | `Ctrl+-` | Horizontal Rule | `---` |
+| Insert → Table | `Ctrl+T` | Table | See table section below |
+| — | `Ctrl+Z` / `Cmd+Z` | Undo | Undo last change |
+| — | `Ctrl+Y` / `Cmd+Y` | Redo | Redo last change |
+
+---
+
+### **Tables**
+| Menu Shortcut | Keyboard Shortcut | Action | Result |
+|---------------|------------------|--------|---------|
+| Insert → Table | `Ctrl+T` | Insert Table | Creates a 3x3 table template |
+
+**Table Template:**
+```
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Row 1    | Data     | Data     |
+| Row 2    | Data     | Data     |
+```
+
+**Table Editing Tips:**
+- Use `|` to separate columns
+- The second row with dashes (`---`) defines the table structure
+- Add `:` for alignment: `:---` (left), `:---:` (center), `---:` (right)
+- Tables automatically format when rendered
+
+---
+
+### **Callouts (Alerts)**
+| Menu Shortcut | Action | Result |
+|---------------|--------|---------|
+| Insert → Callouts → Note | Insert Note Callout | `> [!NOTE] > This is a note callout.` |
+| Insert → Callouts → Tip | Insert Tip Callout | `> [!TIP] > This is a tip callout.` |
+| Insert → Callouts → Warning | Insert Warning Callout | `> [!WARNING] > This is a warning callout.` |
+| Insert → Callouts → Error | Insert Error Callout | `> [!ERROR] > This is an error callout.` |
+
+  
+**Callout Examples:**
+
+> [!NOTE]
+> This is a note callout. Use it for helpful information.
+
+> [!TIP]
+> This is a tip callout. Use it for useful suggestions.
+
+> [!WARNING]
+> This is a warning callout. Use it for important cautions.
+
+> [!ERROR]
+> This is an error callout. Use it for critical issues.
+
+
+**Callout Customization:**
+- Add multiple lines by continuing with `>` prefix
+- Include other markdown formatting inside callouts
+- Callouts support GitHub-flavored markdown syntax
+
+

--- a/frontend/dialob-composer-material/src/dialogs/MarkdownHelpDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/MarkdownHelpDialog.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { useEditor } from "../editor";
+import { FormattedMessage } from "react-intl";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, Table, TableRow, TableCell, TableHead, TableContainer, TableBody, Paper } from "@mui/material";
+import { Close } from "@mui/icons-material";
+import markdownContent from './MARKDOWN_EDITOR.md?raw';
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { markdownComponents } from "../defaults/markdown";
+
+
+const MarkdownHelpDialog: React.FC = () => {
+  const { editor, setMarkdownHelpDialogOpen } = useEditor();
+
+  const open = editor.markdownHelpDialogOpen || false;
+
+  const handleClose = () => {
+    setMarkdownHelpDialogOpen(false);
+  }
+
+  if (!open) {
+    return null;
+  }
+
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth='xl' PaperProps={{ sx: { maxHeight: '70vh' } }}>
+      <DialogTitle sx={{ fontWeight: 'bold' }}>
+        <FormattedMessage id='dialogs.markdown.help.title' />
+      </DialogTitle>
+      <DialogContent sx={{ display: 'flex', borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0, height: '80vh' }}>
+        <Box sx={{ p: 3, width: 1 }}>
+          <Markdown children={markdownContent} remarkPlugins={[remarkGfm]} components={markdownComponents} />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} endIcon={<Close />}><FormattedMessage id='buttons.close' /></Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default MarkdownHelpDialog;

--- a/frontend/dialob-composer-material/src/dialogs/MarkdownHelpDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/MarkdownHelpDialog.tsx
@@ -24,11 +24,11 @@ const MarkdownHelpDialog: React.FC = () => {
 
 
   return (
-    <Dialog open={open} onClose={handleClose} fullWidth maxWidth='xl' PaperProps={{ sx: { maxHeight: '70vh' } }}>
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth='xl'>
       <DialogTitle sx={{ fontWeight: 'bold' }}>
         <FormattedMessage id='dialogs.markdown.help.title' />
       </DialogTitle>
-      <DialogContent sx={{ display: 'flex', borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0, height: '80vh' }}>
+      <DialogContent sx={{ display: 'flex', borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0, height: '90vh' }}>
         <Box sx={{ p: 3, width: 1 }}>
           <Markdown children={markdownContent} remarkPlugins={[remarkGfm]} components={markdownComponents} />
         </Box>

--- a/frontend/dialob-composer-material/src/editor/actions.ts
+++ b/frontend/dialob-composer-material/src/editor/actions.ts
@@ -14,3 +14,4 @@ export type EditorAction =
   | { type: 'setActiveVariableTab', tab?: VariableTabType }
   | { type: 'setConfirmationActiveItem', item?: DialobItem }
   | { type: 'toggleItemCollapsed', itemId: string }
+  | { type: 'setMarkdownHelpDialogOpen', open: boolean }

--- a/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
+++ b/frontend/dialob-composer-material/src/editor/react/useEditor.tsx
@@ -54,6 +54,10 @@ export const useEditor = () => {
     dispatch({ type: 'toggleItemCollapsed', itemId });
   }
 
+  const setMarkdownHelpDialogOpen = (open: boolean): void => {
+    dispatch({ type: 'setMarkdownHelpDialogOpen', open });
+  }
+
   return {
     editor: state,
     setActivePage,
@@ -68,5 +72,6 @@ export const useEditor = () => {
     setActiveVariableTab,
     setConfirmationActiveItem,
     toggleItemCollapsed,
+    setMarkdownHelpDialogOpen,
   };
 }

--- a/frontend/dialob-composer-material/src/editor/reducer.ts
+++ b/frontend/dialob-composer-material/src/editor/reducer.ts
@@ -51,6 +51,10 @@ const toggleItemCollapsed = (state: EditorState, itemId: string): void => {
   state.collapsedItems[itemId] = !state.collapsedItems[itemId];
 }
 
+const setMarkdownHelpDialogOpen = (state: EditorState, open: boolean): void => {
+  state.markdownHelpDialogOpen = open;
+}
+
 export const editorReducer = (state: EditorState, action: EditorAction): EditorState => {
   const newState = produce(state, state => {
     if (action.type === 'setActivePage') {
@@ -77,6 +81,8 @@ export const editorReducer = (state: EditorState, action: EditorAction): EditorS
       setConfirmationActiveItem(state, action.item);
     } else if (action.type === 'toggleItemCollapsed') {
       toggleItemCollapsed(state, action.itemId);
+    } else if (action.type === 'setMarkdownHelpDialogOpen') {
+      setMarkdownHelpDialogOpen(state, action.open);
     }
   });
   return newState;

--- a/frontend/dialob-composer-material/src/editor/types.ts
+++ b/frontend/dialob-composer-material/src/editor/types.ts
@@ -29,4 +29,5 @@ export type EditorState = {
   activeList?: string;
   activeVariableTab?: VariableTabType;
   collapsedItems: Record<string, boolean>;
+  markdownHelpDialogOpen?: boolean;
 };

--- a/frontend/dialob-composer-material/src/intl/en.ts
+++ b/frontend/dialob-composer-material/src/intl/en.ts
@@ -296,6 +296,26 @@ const en = {
   'errors.message.ARRAY_TYPE_UNEXPECTED': 'Array type unexpected',
   'errors.message.FORM_SOURCE_ITEM_NOT_FOUND': 'Form source item not found',
 
+  'markdownEditor.format': 'Format',
+  'markdownEditor.list': 'List',
+  'markdownEditor.paragraph': 'Paragraph',
+  'markdownEditor.insert': 'Insert',
+  'markdownEditor.bold': 'Bold',
+  'markdownEditor.italic': 'Italic',
+  'markdownEditor.code': 'Code',
+  'markdownEditor.bulletList': 'Bullet List',
+  'markdownEditor.numberedList': 'Numbered List',
+  'markdownEditor.body': 'Body',
+  'markdownEditor.link': 'Link',
+  'markdownEditor.codeBlock': 'Code Block',
+  'markdownEditor.horizontalDivider': 'Horizontal Divider',
+  'markdownEditor.table': 'Table',
+  'markdownEditor.callouts': 'Callouts',
+  'markdownEditor.note': 'Note',
+  'markdownEditor.tip': 'Tip',
+  'markdownEditor.warning': 'Warning',
+  'markdownEditor.error': 'Error',
+
 };
 
 export default en;

--- a/frontend/dialob-composer-material/src/intl/en.ts
+++ b/frontend/dialob-composer-material/src/intl/en.ts
@@ -316,6 +316,8 @@ const en = {
   'markdownEditor.warning': 'Warning',
   'markdownEditor.error': 'Error',
 
+  'dialogs.markdown.help.title': 'Markdown Help',
+
 };
 
 export default en;

--- a/frontend/dialob-composer-material/src/theme/siteTheme.ts
+++ b/frontend/dialob-composer-material/src/theme/siteTheme.ts
@@ -221,6 +221,7 @@ const siteTheme = createTheme({
       fontWeight: 300
     },
     h6: {
+      fontSize: "1rem",
       fontFamily: "'IBM Plex Sans Arabic', sans-serif",
       fontWeight: 300
     },

--- a/frontend/dialob-composer-material/src/views/layout/MenuBar.tsx
+++ b/frontend/dialob-composer-material/src/views/layout/MenuBar.tsx
@@ -22,6 +22,7 @@ import { isContextVariable } from '../../utils/ItemUtils';
 import { useDocs } from '../../utils/DocsUtils';
 import { getLanguageName } from '../../utils/TranslationUtils';
 import { SavingProvider } from '../../dialogs/contexts/saving/SavingProvider';
+import MarkdownHelpDialog from '../../dialogs/MarkdownHelpDialog';
 
 
 const ResponsiveButton = styled(Button)(({ theme }) => ({
@@ -167,6 +168,7 @@ const MenuBar: React.FC = () => {
       }}>
         <GlobalListsDialog open={listsDialogOpen} onClose={() => setListsDialogOpen(false)} />
       </SavingProvider>}
+      <MarkdownHelpDialog />
       <TranslationDialog open={translationsDialogOpen} onClose={() => setTranslationsDialogOpen(false)} />
       <FormOptionsDialog open={optionsDialogOpen} onClose={() => setOptionsDialogOpen(false)} />
       <VariablesDialog open={variablesDialogOpen} onClose={() => setVariablesDialogOpen(false)} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,14 +113,23 @@ importers:
         specifier: ^6.16.0
         version: 6.18.7
       '@codemirror/lang-javascript':
-        specifier: ^6.2.1
+        specifier: ^6.2.4
         version: 6.2.4
+      '@codemirror/lang-markdown':
+        specifier: ^6.3.4
+        version: 6.3.4
       '@codemirror/language':
-        specifier: ^6.10.1
+        specifier: ^6.11.3
         version: 6.11.3
       '@codemirror/lint':
-        specifier: ^6.7.1
+        specifier: ^6.8.5
         version: 6.8.5
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.5.2
+      '@codemirror/view':
+        specifier: ^6.38.3
+        version: 6.38.3
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -144,7 +153,7 @@ importers:
         version: 5.18.0(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react@18.3.1))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@uiw/react-codemirror':
         specifier: ^4.21.21
-        version: 4.25.1(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.18.7)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.1)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.25.1(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.18.7)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.3)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -172,6 +181,9 @@ importers:
       react-scroll:
         specifier: ^1.9.0
         version: 1.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.25.1
@@ -1059,8 +1071,17 @@ packages:
   '@codemirror/commands@6.8.1':
     resolution: {integrity: sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==}
 
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.10':
+    resolution: {integrity: sha512-h/SceTVsN5r+WE+TVP2g3KDvNoSzbSrtZXCKo4vkKdbfT5t4otuVgngGdFukOO/rwRD2++pCxoh6xD4TEVMkQA==}
+
   '@codemirror/lang-javascript@6.2.4':
     resolution: {integrity: sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==}
+
+  '@codemirror/lang-markdown@6.3.4':
+    resolution: {integrity: sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==}
 
   '@codemirror/language@6.11.3':
     resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
@@ -1077,8 +1098,8 @@ packages:
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.38.1':
-    resolution: {integrity: sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==}
+  '@codemirror/view@6.38.3':
+    resolution: {integrity: sha512-x2t87+oqwB1mduiQZ6huIghjMt4uZKFEdj66IcXw7+a5iBEvv9lh7EWDRHI7crnD4BMGpnyq/RzmCGbiEZLcvQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1664,14 +1685,23 @@ packages:
   '@lezer/common@1.2.3':
     resolution: {integrity: sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==}
 
+  '@lezer/css@1.3.0':
+    resolution: {integrity: sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==}
+
   '@lezer/highlight@1.2.1':
     resolution: {integrity: sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==}
+
+  '@lezer/html@1.3.10':
+    resolution: {integrity: sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==}
 
   '@lezer/javascript@1.5.1':
     resolution: {integrity: sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==}
 
   '@lezer/lr@1.4.2':
     resolution: {integrity: sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==}
+
+  '@lezer/markdown@1.4.3':
+    resolution: {integrity: sha512-kfw+2uMrQ/wy/+ONfrH83OkdFNM0ye5Xq96cLlaCy7h5UT9FO54DU4oRoIc0CSBh5NWmWuiIJA7NGLMJbQ+Oxg==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -3367,6 +3397,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-plugin-formatjs@5.4.0:
     resolution: {integrity: sha512-ezZdP9i8qjOqZP1PdIjjwL6kLPYFWcqkvlhm/sBbFWkf1xZ00wurXr2+p9YQi+dXQdZvJN4KtvOFHU/hfqx2BQ==}
     peerDependencies:
@@ -4324,12 +4358,36 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -4361,6 +4419,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -4826,11 +4905,17 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -6199,15 +6284,35 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
       '@lezer/common': 1.2.3
 
   '@codemirror/commands@6.8.1':
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
       '@lezer/common': 1.2.3
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@lezer/common': 1.2.3
+      '@lezer/css': 1.3.0
+
+  '@codemirror/lang-html@6.4.10':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.4
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.3
+      '@lezer/common': 1.2.3
+      '@lezer/css': 1.3.0
+      '@lezer/html': 1.3.10
 
   '@codemirror/lang-javascript@6.2.4':
     dependencies:
@@ -6215,14 +6320,24 @@ snapshots:
       '@codemirror/language': 6.11.3
       '@codemirror/lint': 6.8.5
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
       '@lezer/common': 1.2.3
       '@lezer/javascript': 1.5.1
+
+  '@codemirror/lang-markdown@6.3.4':
+    dependencies:
+      '@codemirror/autocomplete': 6.18.7
+      '@codemirror/lang-html': 6.4.10
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.5.2
+      '@codemirror/view': 6.38.3
+      '@lezer/common': 1.2.3
+      '@lezer/markdown': 1.4.3
 
   '@codemirror/language@6.11.3':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
       '@lezer/common': 1.2.3
       '@lezer/highlight': 1.2.1
       '@lezer/lr': 1.4.2
@@ -6231,13 +6346,13 @@ snapshots:
   '@codemirror/lint@6.8.5':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
       crelt: 1.0.6
 
   '@codemirror/search@6.5.11':
     dependencies:
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
       crelt: 1.0.6
 
   '@codemirror/state@6.5.2':
@@ -6248,10 +6363,10 @@ snapshots:
     dependencies:
       '@codemirror/language': 6.11.3
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
       '@lezer/highlight': 1.2.1
 
-  '@codemirror/view@6.38.1':
+  '@codemirror/view@6.38.3':
     dependencies:
       '@codemirror/state': 6.5.2
       crelt: 1.0.6
@@ -7001,9 +7116,21 @@ snapshots:
 
   '@lezer/common@1.2.3': {}
 
+  '@lezer/css@1.3.0':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
+
   '@lezer/highlight@1.2.1':
     dependencies:
       '@lezer/common': 1.2.3
+
+  '@lezer/html@1.3.10':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
+      '@lezer/lr': 1.4.2
 
   '@lezer/javascript@1.5.1':
     dependencies:
@@ -7014,6 +7141,11 @@ snapshots:
   '@lezer/lr@1.4.2':
     dependencies:
       '@lezer/common': 1.2.3
+
+  '@lezer/markdown@1.4.3':
+    dependencies:
+      '@lezer/common': 1.2.3
+      '@lezer/highlight': 1.2.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7621,7 +7753,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.2
+      '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -7965,7 +8097,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       eslint-visitor-keys: 4.2.1
 
-  '@uiw/codemirror-extensions-basic-setup@4.25.1(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)':
+  '@uiw/codemirror-extensions-basic-setup@4.25.1(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.3)':
     dependencies:
       '@codemirror/autocomplete': 6.18.7
       '@codemirror/commands': 6.8.1
@@ -7973,16 +8105,16 @@ snapshots:
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
 
-  '@uiw/react-codemirror@4.25.1(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.18.7)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.1)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@uiw/react-codemirror@4.25.1(@babel/runtime@7.28.4)(@codemirror/autocomplete@6.18.7)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.38.3)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@codemirror/commands': 6.8.1
       '@codemirror/state': 6.5.2
       '@codemirror/theme-one-dark': 6.1.3
-      '@codemirror/view': 6.38.1
-      '@uiw/codemirror-extensions-basic-setup': 4.25.1(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.1)
+      '@codemirror/view': 6.38.3
+      '@uiw/codemirror-extensions-basic-setup': 4.25.1(@codemirror/autocomplete@6.18.7)(@codemirror/commands@6.8.1)(@codemirror/language@6.11.3)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.11)(@codemirror/state@6.5.2)(@codemirror/view@6.38.3)
       codemirror: 6.0.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8621,7 +8753,7 @@ snapshots:
       '@codemirror/lint': 6.8.5
       '@codemirror/search': 6.5.11
       '@codemirror/state': 6.5.2
-      '@codemirror/view': 6.38.1
+      '@codemirror/view': 6.38.3
 
   collect-v8-coverage@1.0.2: {}
 
@@ -8956,6 +9088,8 @@ snapshots:
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-plugin-formatjs@5.4.0(eslint@9.35.0)(ts-jest@29.4.1(@babel/core@7.28.0)(@jest/transform@30.1.2)(@jest/types@30.0.5)(babel-jest@30.1.2(@babel/core@7.28.0))(esbuild@0.25.9)(jest-util@30.0.5)(jest@30.1.3(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.9)))(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
@@ -10408,7 +10542,16 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -10424,6 +10567,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10520,6 +10720,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -11111,6 +11369,17 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -11127,6 +11396,12 @@ snapshots:
       mdast-util-to-hast: 13.2.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
## Created a new component for editing Markdown content - `MarkdownEditor`

  - uses `CodeMirror` for improved language support and syntax highlighting
  
    <img width="540" height="333" alt="image" src="https://github.com/user-attachments/assets/8bfa363a-b3b0-4991-bedb-c8e64ec8c789" />

  - implemented a custom right-click context menu with shortcuts for formatting and inserting content
    
    <img width="271" height="187" alt="image" src="https://github.com/user-attachments/assets/dbb7c711-9aeb-4c94-96bc-d7d4d68c92f7" />
    
    <img width="332" height="176" alt="image" src="https://github.com/user-attachments/assets/afb80c6b-4a5d-47b5-a4b2-a69850f67c7b" />

  - menu renders heading components so the user can tell the difference in different styles and font sizes
    
    <img width="382" height="449" alt="image" src="https://github.com/user-attachments/assets/a5ba21f5-c977-4a44-a99c-fc04636e63da" />

  - added support for rendering more complex Markdown, like tables, code blocks and callouts
    
    <img width="442" height="437" alt="image" src="https://github.com/user-attachments/assets/065f4b76-9538-482a-b2e0-7e1e7dda29f3" />

    <img width="764" height="308" alt="image" src="https://github.com/user-attachments/assets/f1dd4f61-9c7d-4c6b-9da7-0502d5847135" />


  - the Help button inside `ItemOptionsDialog` now opens a fullscreen help dialog that explains how the new Markdown editor works, and shows documentation on using menu and keyboard shortcuts 
    
    <img width="1420" height="752" alt="image" src="https://github.com/user-attachments/assets/74b9a863-26d1-4cd7-9b6a-201be8f8f63f" />
