### PR TITLE
Item type subcategories config for multilevel menu organization

### DIFF
--- a/frontend/dialob-composer-material/README.md
+++ b/frontend/dialob-composer-material/README.md
@@ -103,21 +103,34 @@ Starts preview server for built application from `/dist` (No hot-reload!). Run `
 
 ### Item type configuration
 
-For exmaple: `src/defaults/itemTypes.js`
+Item type configuration defines the structure of the "Add Item" menu and available item types with their properties and behavior.
 
-Item type configuration corresponds to "Add new" item creation menu structure and also defines available item types including their configuration
+**See full example:** [`src/defaults/itemTypes.ts`](src/defaults/itemTypes.ts)
+
+**TypeScript types:** [`src/defaults/types.ts`](src/defaults/types.ts)
+
+#### Menu Structure
+
+The configuration supports **flexible menu nesting** with three options:
+
+1. **Flat structure** - Direct items in a category
+2. **Nested structure** - Items organized in subcategories
+3. **Mixed mode** - Both direct items AND subcategories in the same category
+
+#### Basic Example
 
 ```typescript
- DEFAULT_ITEMTYPE_CONFIG: ItemTypeConfig = {
-   categories: [
+export const DEFAULT_ITEMTYPE_CONFIG: ItemTypeConfig = {
+  categories: [
     {
       title: 'Structure',
       type: 'structure',
       items: [
         {
           title: 'Group',
+          convertible: ['rowgroup'],
           optionEditors: [
-            {name: 'Additional option', editor: PropEditors.InputProp}
+            { name: 'Additional option', editor: PropEditors.InputProp }
           ],
           propEditors: {
             columns: {
@@ -135,56 +148,128 @@ Item type configuration corresponds to "Add new" item creation menu structure an
               columns: 1
             }
           }
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Nested Structure with Subcategories
+
+```typescript
+{
+  title: 'Inputs',
+  type: 'input',
+  subcategories: [
+    {
+      title: 'Text fields',
+      items: [
+        {
+          title: 'Text',
+          convertible: ['textBox', 'address'],
+          config: {
+            type: 'text',
+            view: 'text'
+          }
         },
         {
-          title: 'Multi-choice',
-          convertible: ['list'],
-          propEditors: {
-            display: {
-              component: PropEditors.ChoiceProp,
-              props: {
-                options: [
-                  {key: 'dropdown', label: 'Dropdown'},
-                  {key: 'button', label: 'Button'},
-                  {key: 'checkbox', label: 'Checkbox'}
-                ]
-              }
-            }
-          },
+          title: 'Text box',
+          convertible: ['text', 'address'],
           config: {
-            type: 'multichoice',
-            props: {
-              display: 'dropdown',
-            }
+            type: 'text',
+            view: 'textBox'
           }
         }
       ]
     },
-        // ....
+    {
+      title: 'Numbers',
+      items: [
+        {
+          title: 'Decimal',
+          config: { type: 'decimal' }
+        },
+        {
+          title: 'Integer',
+          config: { type: 'number' }
+        }
       ]
-    },
-    // ....
+    }
   ]
- }
+}
 ```
 
-See: `src/defaults/type.ts` for TypeScript types
+This creates a menu hierarchy:
+```
+Inputs →
+  ├─ Text fields →
+  │    ├─ Text
+  │    └─ Text box
+  └─ Numbers →
+       ├─ Decimal
+       └─ Integer
+```
 
-* `categories` defines top-level categories, category object contains following attributes:
-  * `Title` Label used in UI
-  * `type` Category type, allowed values: `structure`, `input`, `output` - These are used to limit certain categories of items to be added into form depending on conditions
-  * `items` Array of item configurations within this category. Item objects contain following attributes
-    * `title` Label used in UI
-    * `convertible` (Optional) Array of item type identifiers into which this item can be converted. Entries are first matched by `view` attribute, if not found then by `type`. If omitted, item can't be converted to other types.
-    * `optionEditors` (Optional) Array of additional pages for item options dialog. Array of objects: `{name: 'Title of page', editor: OptionEditorComponent}` (see below)
-    * `propEditors` (Optional) if custom property editors are configured for item. If prop editor is not defined, it will be fallen back to plain text. Editor configuration is set of objects having prop name as a key:
-      * `component` : React component to use for editing the prop
-      * `props` : (Optional) Additional properties for the editing component. (see below)
-    * `config` : Snippet of Dialob form item configuration (See Dialob Form API). Any predefined structure is supported. only mandatory attribute is `type`. Item's default ID will be based on `view` attribute falling back to `type`
+#### Mixed Mode (Direct Items + Subcategories)
 
-**Note!** `props` Are item specific properties that are available at filling time
+You can combine both approaches in the same category:
 
-#### Prop editor configrurations
+```typescript
+{
+  title: 'Inputs',
+  type: 'input',
+  items: [
+    // Direct items (no submenu)
+    { title: 'Boolean', config: { type: 'boolean' } },
+    { title: 'Date', config: { type: 'date' } }
+  ],
+  subcategories: [
+    // Nested items (with submenu)
+    {
+      title: 'Text fields',
+      items: [
+        { title: 'Text', config: { type: 'text', view: 'text' } },
+        { title: 'Text box', config: { type: 'text', view: 'textBox' } }
+      ]
+    }
+  ]
+}
+```
+
+Renders as:
+```
+Inputs →
+  ├─ Boolean (clickable)
+  ├─ Date (clickable)
+  ├─── (separator) ───
+  └─ Text fields →
+       ├─ Text
+       └─ Text box
+```
+
+#### Configuration Reference
+
+**Category attributes:**
+* **`title`** - Label displayed in the menu
+* **`type`** - Category type: `'structure'`, `'input'`, or `'output'`. Used to filter which items can be added in different contexts
+* **`items`** - (Optional) Array of item configurations for direct menu items
+* **`subcategories`** - (Optional) Array of subcategory objects for nested menu structure
+
+**Subcategory attributes:**
+* **`title`** - Label displayed in the submenu
+* **`items`** - Array of item configurations
+
+**Item attributes:**
+* **`title`** - Label displayed in the menu
+* **`convertible`** - (Optional) Array of type identifiers this item can be converted to. Matched by `view` first, then `type`. If omitted, item cannot be converted
+* **`optionEditors`** - (Optional) Additional option pages for the item dialog: `{name: 'Title', editor: Component}`
+* **`propEditors`** - (Optional) Custom property editors (see below). If not defined, falls back to plain text input
+* **`config`** - Dialob form item configuration snippet. Required field: `type`. The item's default ID is based on `view` (if present) or `type`
+
+**Note:** `props` in the config are item-specific properties available at form filling time, not to be confused with React component props.
+
+#### Prop Editor Configurations
 
 Built in editors:
 

--- a/frontend/dialob-composer-material/src/components/PageTabs.tsx
+++ b/frontend/dialob-composer-material/src/components/PageTabs.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_ITEMTYPE_CONFIG } from "../defaults";
 import { FormattedMessage } from "react-intl";
 import { useBackend } from "../backend/useBackend";
 import { DialobItem, DialobItems } from "../types";
+import { getCategoryItems } from "../utils/ConfigUtils";
 
 
 const MAX_PAGE_NAME_LENGTH = 40;
@@ -98,7 +99,8 @@ const PageTabs: React.FC<{ items: DialobItems }> = ({ items }) => {
   const handleCreate = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     const resolvedConfig = config.itemTypes ?? DEFAULT_ITEMTYPE_CONFIG;
-    const groupTemplate = resolvedConfig.categories.find(c => c.type === 'structure')!.items.find(i => i.config.type === 'group')!.config;
+    const structureCategory = resolvedConfig.categories.find(c => c.type === 'structure')!;
+    const groupTemplate = getCategoryItems(structureCategory).find(i => i.config.type === 'group')!.config;
     const pageTemplate = { ...groupTemplate, view: 'page' };
     addItem(pageTemplate, 'questionnaire');
   }

--- a/frontend/dialob-composer-material/src/components/editors/RuleEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/RuleEditor.tsx
@@ -9,6 +9,7 @@ import { getErrorSeverity } from '../../utils/ErrorUtils';
 import { DEFAULT_ITEMTYPE_CONFIG } from '../../defaults';
 import { useBackend } from '../../backend/useBackend';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
+import { getCategoryItems } from '../../utils/ConfigUtils';
 
 type RuleType = 'visibility' | 'requirement' | 'canaddrow' | 'canremoverow';
 
@@ -40,7 +41,8 @@ const RuleEditor: React.FC<{ type: RuleType }> = ({ type }) => {
     return null;
   }
 
-  if (!resolvedConfig.categories.find(c => c.type === 'input')?.items.find(i => i.config.type === item.type) && type === 'requirement') {
+  const inputCategory = resolvedConfig.categories.find(c => c.type === 'input');
+  if (inputCategory && !getCategoryItems(inputCategory).find(i => i.config.type === item.type) && type === 'requirement') {
     return null;
   }
 

--- a/frontend/dialob-composer-material/src/defaults/itemTypes.ts
+++ b/frontend/dialob-composer-material/src/defaults/itemTypes.ts
@@ -80,144 +80,166 @@ export const DEFAULT_ITEMTYPE_CONFIG: ItemTypeConfig = {
           }
         },
         {
-          title: 'Text',
-          convertible: ['textBox', 'address', 'ytunnus', 'iban', 'hetu'],
-          config: {
-            type: 'text',
-            view: 'text'
-          }
-        },
-        {
-          title: 'Text box',
-          convertible: ['text', 'address', 'ytunnus', 'iban', 'hetu'],
-          config: {
-            type: 'text',
-            view: 'textBox'
-          }
-        },
-        {
-          title: 'Address',
-          convertible: ['text', 'textBox'],
-          propEditors: {
-            country: {
-              component: PropEditors.MultiChoiceProp,
-              props: {
-                allowAdditions: true,
-                options: [
-                  { key: 'fi', label: 'Finland' },
-                  { key: 'sv', label: 'Sweden' },
-                  { key: 'ee', label: 'Estonia' }
-                ]
-              }
-            }
-          },
-          config: {
-            type: 'text',
-            view: 'address',
-            props: {
-              country: []
-            }
-          }
-        },
-        {
-          title: 'Decimal',
-          convertible: ['number'],
-          config: {
-            type: 'decimal'
-          }
-        },
-        {
-          title: 'Integer',
-          convertible: ['decimal'],
-          config: {
-            type: 'number'
-          }
-        },
-        {
           title: 'Boolean',
           config: {
             type: 'boolean'
           }
-        },
+        }
+      ],
+      subcategories: [
         {
-          title: 'Date',
-          config: {
-            type: 'date'
-          }
-        },
-        {
-          title: 'Time',
-          config: {
-            type: 'time'
-          }
-        },
-        {
-          title: 'Choice',
-          convertible: ['multichoice'],
-          config: {
-            type: 'list'
-          }
-        },
-        {
-          title: 'Multi-choice',
-          convertible: ['list'],
-          config: {
-            type: 'multichoice'
-          }
-        },
-        {
-          title: 'Personal identity code (HETU)',
-          convertible: ['text', 'textBox', 'ytunnus', 'iban'],
-          config: {
-            type: 'text',
-            view: 'hetu',
-            validations: [
-              {
-                rule: 'isNotHetu(answer)',
-                message: {
-                  en: 'Check your personal FI identity code.',
-                  fi: 'Kontrollera ditt FI personnummer.',
-                  sv: 'Invalid Finnish personal ID!'
+          title: 'Text fields',
+          items: [
+            {
+              title: 'Text',
+              convertible: ['textBox', 'address', 'ytunnus', 'iban', 'hetu'],
+              config: {
+                type: 'text',
+                view: 'text'
+              }
+            },
+            {
+              title: 'Text box',
+              convertible: ['text', 'address', 'ytunnus', 'iban', 'hetu'],
+              config: {
+                type: 'text',
+                view: 'textBox'
+              }
+            },
+            {
+              title: 'Address',
+              convertible: ['text', 'textBox'],
+              propEditors: {
+                country: {
+                  component: PropEditors.MultiChoiceProp,
+                  props: {
+                    allowAdditions: true,
+                    options: [
+                      { key: 'fi', label: 'Finland' },
+                      { key: 'sv', label: 'Sweden' },
+                      { key: 'ee', label: 'Estonia' }
+                    ]
+                  }
+                }
+              },
+              config: {
+                type: 'text',
+                view: 'address',
+                props: {
+                  country: []
                 }
               }
-            ]
-          }
+            },
+            {
+              title: 'Personal identity code (HETU)',
+              convertible: ['text', 'textBox', 'ytunnus', 'iban'],
+              config: {
+                type: 'text',
+                view: 'hetu',
+                validations: [
+                  {
+                    rule: 'isNotHetu(answer)',
+                    message: {
+                      en: 'Check your personal FI identity code.',
+                      fi: 'Kontrollera ditt FI personnummer.',
+                      sv: 'Invalid Finnish personal ID!'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              title: 'Company business ID (y-tunnus)',
+              convertible: ['text', 'textBox', 'hetu', 'iban'],
+              config: {
+                type: 'text',
+                view: 'ytunnus',
+                validations: [
+                  {
+                    rule: 'isNotLyt(answer)',
+                    message: {
+                      en: 'Check the business ID you provided.',
+                      fi: 'Tarkista antamasi yritystunnus.',
+                      sv: 'Kontrollera ditt företagsnummer.'
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              title: 'Account number in IBAN format',
+              convertible: ['text', 'textBox', 'ytunnus', 'hetu'],
+              config: {
+                type: 'text',
+                view: 'iban',
+                validations: [
+                  {
+                    rule: 'isNotIban(answer)',
+                    message: {
+                      en: 'Check that the account number you provided is correct and in IBAN format.',
+                      fi: 'Tarkista, että antamasi tilinumero on oikein ja IBAN -muodossa.',
+                      sv: 'Kontrollera att det kontonummer du angivit är korrekt och i IBAN-format.'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
-          title: 'Company business ID (y-tunnus)',
-          convertible: ['text', 'textBox', 'hetu', 'iban'],
-          config: {
-            type: 'text',
-            view: 'ytunnus',
-            validations: [
-              {
-                rule: 'isNotLyt(answer)',
-                message: {
-                  en: 'Check the business ID you provided.',
-                  fi: 'Tarkista antamasi yritystunnus.',
-                  sv: 'Kontrollera ditt företagsnummer.'
-                }
+          title: 'Numbers',
+          items: [
+            {
+              title: 'Decimal',
+              convertible: ['number'],
+              config: {
+                type: 'decimal'
               }
-            ]
-          }
+            },
+            {
+              title: 'Integer',
+              convertible: ['decimal'],
+              config: {
+                type: 'number'
+              }
+            }
+          ]
         },
         {
-          title: 'Account number in IBAN format',
-          convertible: ['text', 'textBox', 'ytunnus', 'hetu'],
-          config: {
-            type: 'text',
-            view: 'iban',
-            validations: [
-              {
-                rule: 'isNotIban(answer)',
-                message: {
-                  en: 'Check that the account number you provided is correct and in IBAN format.',
-                  fi: 'Tarkista, että antamasi tilinumero on oikein ja IBAN -muodossa.',
-                  sv: 'Kontrollera att det kontonummer du angivit är korrekt och i IBAN-format.'
-                }
+          title: 'Date & Time',
+          items: [
+            {
+              title: 'Date',
+              config: {
+                type: 'date'
               }
-            ]
-          }          
+            },
+            {
+              title: 'Time',
+              config: {
+                type: 'time'
+              }
+            }
+          ]
+        },
+        {
+          title: 'Selections',
+          items: [
+            {
+              title: 'Choice',
+              convertible: ['multichoice'],
+              config: {
+                type: 'list'
+              }
+            },
+            {
+              title: 'Multi-choice',
+              convertible: ['list'],
+              config: {
+                type: 'multichoice'
+              }
+            }
+          ]
         }
       ]
     },

--- a/frontend/dialob-composer-material/src/defaults/types.ts
+++ b/frontend/dialob-composer-material/src/defaults/types.ts
@@ -29,6 +29,12 @@ export interface ItemTypeConfig {
 export interface ItemTypeCategory {
   title: string,
   type: DialobCategoryType,
+  items?: CategoryItem[],
+  subcategories?: Subcategory[]
+}
+
+export interface Subcategory {
+  title: string,
   items: CategoryItem[]
 }
 

--- a/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/ItemOptionsDialog.tsx
@@ -17,6 +17,7 @@ import { useDocs } from '../utils/DocsUtils';
 import { SavingProvider } from './contexts/saving/SavingProvider';
 import { useSave } from './contexts/saving/useSave';
 import { DialobItem } from '../types';
+import { getCategoryItems } from '../utils/ConfigUtils';
 
 const StyledButtonContainer = styled(Box)(({ theme }) => ({
   '& .MuiButton-root': {
@@ -112,7 +113,8 @@ const ItemOptionsDialog: React.FC = () => {
   const [id, setId] = React.useState<string>(item?.id || '');
   const [idError, setIdError] = React.useState<boolean>(false);
   const resolvedConfig = config.itemTypes ?? DEFAULT_ITEMTYPE_CONFIG;
-  const isInputType = item && resolvedConfig.categories.find(c => c.type === 'input')?.items.some(i => i.config.type === item.type);
+  const inputCategory = resolvedConfig.categories.find(c => c.type === 'input');
+  const isInputType = item && inputCategory && getCategoryItems(inputCategory).some(i => i.config.type === item.type);
   const docsUrl = useDocs(activeTab);
 
   React.useEffect(() => {

--- a/frontend/dialob-composer-material/src/items/ItemComponents.tsx
+++ b/frontend/dialob-composer-material/src/items/ItemComponents.tsx
@@ -20,6 +20,120 @@ const MAX_LABEL_LENGTH_WITH_INDICATORS = 45;
 const MAX_LABEL_LENGTH_WITHOUT_INDICATORS = 65;
 const MAX_RULE_LENGTH = 80;
 
+interface MenuAnchorOrigin {
+  vertical: 'top' | 'bottom';
+  horizontal: 'left' | 'right';
+}
+
+interface SubcategoryMenuProps {
+  subcategory: { title: string; items: { title: string; config: DialobItemTemplate }[] };
+  isOpen: boolean;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  onCreate: (e: React.MouseEvent<HTMLElement>, config: DialobItemTemplate) => void;
+  anchorOrigin?: MenuAnchorOrigin;
+  transformOrigin?: MenuAnchorOrigin;
+}
+
+interface CategoryMenuProps {
+  category: { title: string; items?: { title: string; config: DialobItemTemplate }[]; subcategories?: { title: string; items: { title: string; config: DialobItemTemplate }[] }[] };
+  isOpen: boolean;
+  anchorEl: HTMLElement | null;
+  chosenSubcategory: string | null;
+  subcategoryRefs: React.MutableRefObject<{ [key: string]: HTMLElement | null }>;
+  onClose: () => void;
+  onCreate: (e: React.MouseEvent<HTMLElement>, config: DialobItemTemplate) => void;
+  onSubcategoryClick: (e: React.MouseEvent<HTMLElement>, title: string) => void;
+  anchorOrigin?: MenuAnchorOrigin;
+  transformOrigin?: MenuAnchorOrigin;
+}
+
+const renderSubcategoryMenu = ({
+  subcategory,
+  isOpen,
+  anchorEl,
+  onClose,
+  onCreate,
+  anchorOrigin = { vertical: 'top', horizontal: 'right' },
+  transformOrigin
+}: SubcategoryMenuProps) => (
+  <Menu
+    open={isOpen}
+    onClose={onClose}
+    anchorEl={anchorEl}
+    disableScrollLock={true}
+    anchorOrigin={anchorOrigin}
+    transformOrigin={transformOrigin}
+    style={{ pointerEvents: 'none' }}
+    slotProps={{ paper: { style: { pointerEvents: 'auto' } } }}
+  >
+    {subcategory.items.map((i, itemIndex) => (
+      <MenuItem key={itemIndex} onClick={(e) => onCreate(e, i.config)}>
+        <Typography>{i.title}</Typography>
+      </MenuItem>
+    ))}
+  </Menu>
+);
+
+const renderCategoryMenu = ({
+  category,
+  isOpen,
+  anchorEl,
+  chosenSubcategory,
+  subcategoryRefs,
+  onClose,
+  onCreate,
+  onSubcategoryClick,
+  anchorOrigin = { vertical: 'top', horizontal: 'right' },
+  transformOrigin
+}: CategoryMenuProps) => {
+  const hasItems = category.items && category.items.length > 0;
+  const hasSubcategories = category.subcategories && category.subcategories.length > 0;
+
+  return (
+    <Menu
+      open={isOpen}
+      onClose={onClose}
+      anchorEl={anchorEl}
+      disableScrollLock={true}
+      anchorOrigin={anchorOrigin}
+      transformOrigin={transformOrigin}
+      style={{ pointerEvents: 'none' }}
+      slotProps={{ paper: { style: { pointerEvents: 'auto' } } }}
+    >
+      {hasItems && category.items!.map((i, itemIndex) => (
+        <MenuItem key={`item-${itemIndex}`} onClick={(e) => onCreate(e, i.config)}>
+          <Typography>{i.title}</Typography>
+        </MenuItem>
+      ))}
+      
+      {hasItems && hasSubcategories && <Divider />}
+
+      {hasSubcategories && category.subcategories!.map((sub, subIndex) => {
+        const isSubcategoryOpen = sub.title === chosenSubcategory;
+
+        return (
+          <React.Fragment key={`sub-${subIndex}`}>
+            <MenuItem onClick={(e) => onSubcategoryClick(e, sub.title)}>
+              <Typography>{sub.title}</Typography>
+              <KeyboardArrowRight sx={{ ml: 1 }} fontSize='small' />
+            </MenuItem>
+            {renderSubcategoryMenu({
+              subcategory: sub,
+              isOpen: isSubcategoryOpen,
+              anchorEl: subcategoryRefs.current[sub.title],
+              onClose,
+              onCreate,
+              anchorOrigin,
+              transformOrigin
+            })}
+          </React.Fragment>
+        );
+      })}
+    </Menu>
+  );
+};
+
 const ItemHeaderButton = styled(Button)(({ theme }) => ({
   padding: theme.spacing(1),
   paddingLeft: theme.spacing(2),
@@ -73,7 +187,13 @@ const resolveTypeName = (type: string | undefined, itemTypeConfig: ItemTypeConfi
   if (!type) {
     return '';
   }
-  const items = itemTypeConfig.categories.flatMap(c => c.items);
+  const items = itemTypeConfig.categories.flatMap(c => {
+    const directItems = c.items || [];
+    const subcategoryItems = c.subcategories 
+      ? c.subcategories.flatMap(sub => sub.items)
+      : [];
+    return [...directItems, ...subcategoryItems];
+  });
   const item = items.find(i => i.config.view === type || i.config.type === type);
   if (item) {
     return item.title;
@@ -211,7 +331,11 @@ export const ConversionMenu: React.FC<{ item?: DialobItem, inDialog?: boolean }>
 
   const handleConvert = (e: React.MouseEvent<HTMLElement>, config: DialobItemTemplate) => {
     handleClose(e);
-    inDialog ? convertInDialog(item.id, config) : changeItemType(item.id, config);
+    if (inDialog) {
+      convertInDialog(item.id, config);
+    } else {
+      changeItemType(item.id, config);
+    }
     setTypeName(resolveTypeName(config.type, config.itemTypes));
   }
 
@@ -246,60 +370,68 @@ export const OptionsMenu: React.FC<{ item: DialobItem, isPage?: boolean, light?:
   const { setConfirmationDialogType, setActiveItem, setConfirmationActiveItem, setItemOptionsActiveTab, setHighlightedItem } = useEditor();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [categoriesAnchorEl, setCategoriesAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [itemsAnchorEl, setItemsAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [chosenCategory, setChosenCategory] = React.useState<string | null>('');
+  const [chosenCategory, setChosenCategory] = React.useState<string | null>(null);
+  const [chosenSubcategory, setChosenSubcategory] = React.useState<string | null>(null);
   const open = Boolean(anchorEl);
   const categoriesOpen = Boolean(categoriesAnchorEl);
   const itemCategories = config.itemTypes.categories;
+  const categoryRefs = React.useRef<{ [key: string]: HTMLElement | null }>({});
+  const subcategoryRefs = React.useRef<{ [key: string]: HTMLElement | null }>({});
 
-  const handleClick = (e: React.MouseEvent<HTMLElement>, level: number, category?: string) => {
+  const handleClick = (e: React.MouseEvent<HTMLElement>, level: number) => {
     if (level === 2) {
       setCategoriesAnchorEl(e.currentTarget);
-    } else if (level === 3 && category) {
-      setItemsAnchorEl(e.currentTarget);
-      setChosenCategory(category);
     } else {
       setAnchorEl(e.currentTarget);
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleClose = (e: any, level: number) => {
+  const handleCategoryClick = (e: React.MouseEvent<HTMLElement>, categoryTitle: string) => {
     e.stopPropagation();
-    if (level === 2) {
-      setCategoriesAnchorEl(null);
-    } else if (level === 3) {
-      setItemsAnchorEl(null);
+    categoryRefs.current[categoryTitle] = e.currentTarget;
+    if (chosenCategory === categoryTitle) {
       setChosenCategory(null);
+      setChosenSubcategory(null);
     } else {
-      setAnchorEl(null);
+      setChosenCategory(categoryTitle);
+      setChosenSubcategory(null);
+    }
+  };
+
+  const handleSubcategoryClick = (e: React.MouseEvent<HTMLElement>, subcategoryTitle: string) => {
+    e.stopPropagation();
+    subcategoryRefs.current[subcategoryTitle] = e.currentTarget;
+    if (chosenSubcategory === subcategoryTitle) {
+      setChosenSubcategory(null);
+    } else {
+      setChosenSubcategory(subcategoryTitle);
     }
   };
 
   const handleCloseAll = () => {
     setAnchorEl(null);
     setCategoriesAnchorEl(null);
-    setItemsAnchorEl(null);
     setChosenCategory(null);
+    setChosenSubcategory(null);
   }
 
   const handleOptions = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
-    handleClose(e, 1);
+    handleCloseAll();
     setActiveItem(item);
     setItemOptionsActiveTab('label');
   }
 
   const handleDelete = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
-    handleClose(e, 1);
+    handleCloseAll();
     setConfirmationActiveItem(item);
     setConfirmationDialogType('delete');
   }
 
   const handleDuplicate = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
-    handleClose(e, 1);
+    handleCloseAll();
     setConfirmationActiveItem(item);
     setConfirmationDialogType('duplicate');
   }
@@ -323,7 +455,7 @@ export const OptionsMenu: React.FC<{ item: DialobItem, isPage?: boolean, light?:
         sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <MenuIcon sx={{ color: light ? 'white' : 'inherit', '&:hover': { color: 'divider', cursor: 'pointer' } }} />
       </Box>
-      <Menu open={open} onClose={(e) => handleClose(e, 1)} anchorEl={anchorEl} disableScrollLock={true}>
+      <Menu open={open} onClose={handleCloseAll} anchorEl={anchorEl} disableScrollLock={true}>
         <MenuItem onClick={(e) => handleOptions(e)}>
           <Tune sx={{ mr: 1 }} fontSize='small' />
           <FormattedMessage id='menus.options' />
@@ -341,22 +473,39 @@ export const OptionsMenu: React.FC<{ item: DialobItem, isPage?: boolean, light?:
           <FormattedMessage id='menus.insert.below' />
           <KeyboardArrowRight sx={{ ml: 1 }} fontSize='small' />
         </MenuItem>}
-        <Menu open={categoriesOpen} onClose={(e) => handleClose(e, 2)} anchorEl={categoriesAnchorEl}
-          disableScrollLock={true} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
-          {itemCategories.map((c, index) => (
-            <MenuItem key={index} onClick={(e) => handleClick(e, 3, c.title)}>
-              <Typography>{c.title}</Typography>
-              <KeyboardArrowRight sx={{ ml: 1 }} fontSize='small' />
-              <Menu open={c.title === chosenCategory} onClose={(e) => handleClose(e, 3)} anchorEl={itemsAnchorEl}
-                disableScrollLock={true} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
-                {c.items.map((i, index) => (
-                  <MenuItem key={index} onClick={(e) => handleCreate(e, i.config)}>
-                    <Typography>{i.title}</Typography>
+        <Menu open={categoriesOpen} onClose={handleCloseAll} anchorEl={categoriesAnchorEl}
+          disableScrollLock={true} 
+          anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}>
+          {itemCategories.map((c, index) => {
+            const hasSubcategories = c.subcategories && c.subcategories.length > 0;
+            const hasItems = c.items && c.items.length > 0;
+            const isCategoryOpen = c.title === chosenCategory;
+
+            if (hasSubcategories || hasItems) {
+              return (
+                <React.Fragment key={index}>
+                  <MenuItem onClick={(e) => handleCategoryClick(e, c.title)}>
+                    <Typography>{c.title}</Typography>
+                    <KeyboardArrowRight sx={{ ml: 1 }} fontSize='small' />
                   </MenuItem>
-                ))}
-              </Menu>
-            </MenuItem>
-          ))}
+                  {renderCategoryMenu({
+                    category: c,
+                    isOpen: isCategoryOpen,
+                    anchorEl: categoryRefs.current[c.title],
+                    chosenSubcategory,
+                    subcategoryRefs,
+                    onClose: handleCloseAll,
+                    onCreate: handleCreate,
+                    onSubcategoryClick: handleSubcategoryClick,
+                    anchorOrigin: { vertical: 'top', horizontal: 'left' },
+                    transformOrigin: { vertical: 'top', horizontal: 'right' }
+                  })}
+                </React.Fragment>
+              );
+            }
+            return null;
+          })}
         </Menu>
       </Menu>
     </>
@@ -368,30 +517,49 @@ export const AddItemMenu: React.FC<{ item: DialobItem }> = ({ item }) => {
   const { setHighlightedItem } = useEditor();
   const { config } = useBackend();
   const [categoriesAnchorEl, setCategoriesAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [itemsAnchorEl, setItemsAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [chosenCategory, setChosenCategory] = React.useState<string | null>('');
+  const [chosenCategory, setChosenCategory] = React.useState<string | null>(null);
+  const [chosenSubcategory, setChosenSubcategory] = React.useState<string | null>(null);
   const categoriesOpen = Boolean(categoriesAnchorEl);
   const itemCategories = config.itemTypes.categories;
+  const categoryRefs = React.useRef<{ [key: string]: HTMLElement | null }>({});
+  const subcategoryRefs = React.useRef<{ [key: string]: HTMLElement | null }>({});
 
-  const handleClick = (e: React.MouseEvent<HTMLElement>, category?: string) => {
+  const handleButtonClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
-    if (category) {
-      setItemsAnchorEl(e.currentTarget);
-      setChosenCategory(category);
+    setCategoriesAnchorEl(e.currentTarget);
+  };
+
+  const handleCategoryClick = (e: React.MouseEvent<HTMLElement>, categoryTitle: string) => {
+    e.stopPropagation();
+    categoryRefs.current[categoryTitle] = e.currentTarget;
+    if (chosenCategory === categoryTitle) {
+      setChosenCategory(null);
+      setChosenSubcategory(null);
     } else {
-      setCategoriesAnchorEl(e.currentTarget);
+      setChosenCategory(categoryTitle);
+      setChosenSubcategory(null);
     }
   };
 
-  const handleClose = (e: React.MouseEvent<HTMLElement>) => {
+  const handleSubcategoryClick = (e: React.MouseEvent<HTMLElement>, subcategoryTitle: string) => {
     e.stopPropagation();
+    subcategoryRefs.current[subcategoryTitle] = e.currentTarget;
+    if (chosenSubcategory === subcategoryTitle) {
+      setChosenSubcategory(null);
+    } else {
+      setChosenSubcategory(subcategoryTitle);
+    }
+  };
+
+  const handleClose = () => {
     setCategoriesAnchorEl(null);
-    setItemsAnchorEl(null);
     setChosenCategory(null);
+    setChosenSubcategory(null);
   };
 
   const handleCreate = (e: React.MouseEvent<HTMLElement>, itemTemplate: DialobItemTemplate) => {
-    handleClose(e);
+    e.stopPropagation();
+    handleClose();
     addItem(itemTemplate, item.id, undefined, { onAddItem: postCreate });
   }
 
@@ -402,25 +570,38 @@ export const AddItemMenu: React.FC<{ item: DialobItem }> = ({ item }) => {
 
   return (
     <>
-      <Button onClick={handleClick} variant='contained' color='inherit' endIcon={<KeyboardArrowDown />}>
+      <Button onClick={handleButtonClick} variant='contained' color='inherit' endIcon={<KeyboardArrowDown />}>
         <Typography><FormattedMessage id='menus.add' /></Typography>
       </Button>
       <Menu open={categoriesOpen} onClose={handleClose} anchorEl={categoriesAnchorEl}
         disableScrollLock={true} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
-        {itemCategories.map((c, index) => (
-          <MenuItem key={index} onClick={(e) => handleClick(e, c.title)}>
-            <Typography>{c.title}</Typography>
-            <KeyboardArrowRight sx={{ ml: 1 }} fontSize='small' />
-            <Menu open={c.title === chosenCategory} onClose={handleClose} anchorEl={itemsAnchorEl}
-              disableScrollLock={true} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
-              {c.items.map((i, index) => (
-                <MenuItem key={index} onClick={(e) => handleCreate(e, i.config)}>
-                  <Typography>{i.title}</Typography>
+        {itemCategories.map((c, index) => {
+          const hasSubcategories = c.subcategories && c.subcategories.length > 0;
+          const hasItems = c.items && c.items.length > 0;
+          const isCategoryOpen = c.title === chosenCategory;
+
+          if (hasSubcategories || hasItems) {
+            return (
+              <React.Fragment key={index}>
+                <MenuItem onClick={(e) => handleCategoryClick(e, c.title)}>
+                  <Typography>{c.title}</Typography>
+                  <KeyboardArrowRight sx={{ ml: 1 }} fontSize='small' />
                 </MenuItem>
-              ))}
-            </Menu>
-          </MenuItem>
-        ))}
+                {renderCategoryMenu({
+                  category: c,
+                  isOpen: isCategoryOpen,
+                  anchorEl: categoryRefs.current[c.title],
+                  chosenSubcategory,
+                  subcategoryRefs,
+                  onClose: handleClose,
+                  onCreate: handleCreate,
+                  onSubcategoryClick: handleSubcategoryClick
+                })}
+              </React.Fragment>
+            );
+          }
+          return null;
+        })}
       </Menu>
     </>
   )

--- a/frontend/dialob-composer-material/src/utils/ConfigUtils.tsx
+++ b/frontend/dialob-composer-material/src/utils/ConfigUtils.tsx
@@ -1,11 +1,31 @@
-import { ItemTypeConfig } from "../defaults/types";
+import { CategoryItem, ItemTypeConfig, ItemTypeCategory } from "../defaults/types";
+
+export const getCategoryItems = (category: ItemTypeCategory): CategoryItem[] => {
+  const directItems = category.items || [];
+  const subcategoryItems = category.subcategories 
+    ? category.subcategories.flatMap(sub => sub.items)
+    : [];
+  return [...directItems, ...subcategoryItems];
+};
 
 export const findItemTypeConfig = (itemTypes: ItemTypeConfig, type: string, view?: string) => {
   for (const idx in itemTypes.categories) {
     const c = itemTypes.categories[idx];
-    const resultConfig = c.items.find(v => v.config.type === type && (!view || v.config.view === view));
-    if (resultConfig) {
-      return resultConfig;
+    // Check direct items
+    if (c.items) {
+      const resultConfig = c.items.find(v => v.config.type === type && (!view || v.config.view === view));
+      if (resultConfig) {
+        return resultConfig;
+      }
+    }
+    // Check subcategories
+    if (c.subcategories) {
+      for (const sub of c.subcategories) {
+        const resultConfig = sub.items.find(v => v.config.type === type && (!view || v.config.view === view));
+        if (resultConfig) {
+          return resultConfig;
+        }
+      }
     }
   }
   return null;
@@ -14,9 +34,21 @@ export const findItemTypeConfig = (itemTypes: ItemTypeConfig, type: string, view
 export const findItemTypeConvertible = (itemTypes: ItemTypeConfig, view: string) => {
   for (const idx in itemTypes.categories) {
     const c = itemTypes.categories[idx];
-    const resultConfig = c.items.find(v => v.config.type === view || v.config.view === view);
-    if (resultConfig) {
-      return resultConfig;
+    // Check direct items
+    if (c.items) {
+      const resultConfig = c.items.find(v => v.config.type === view || v.config.view === view);
+      if (resultConfig) {
+        return resultConfig;
+      }
+    }
+    // Check subcategories
+    if (c.subcategories) {
+      for (const sub of c.subcategories) {
+        const resultConfig = sub.items.find(v => v.config.type === view || v.config.view === view);
+        if (resultConfig) {
+          return resultConfig;
+        }
+      }
     }
   }
   return null;
@@ -25,9 +57,21 @@ export const findItemTypeConvertible = (itemTypes: ItemTypeConfig, view: string)
 export const findItemPropEditor = (itemTypes: ItemTypeConfig, view: string) => {
   for (const idx in itemTypes.categories) {
     const c = itemTypes.categories[idx];
-    const resultConfig = c.items.find(v => v.config.type === view || v.config.view === view);
-    if (resultConfig && resultConfig.propEditors) {
-      return resultConfig.propEditors;
+    // Check direct items
+    if (c.items) {
+      const resultConfig = c.items.find(v => v.config.type === view || v.config.view === view);
+      if (resultConfig && resultConfig.propEditors) {
+        return resultConfig.propEditors;
+      }
+    }
+    // Check subcategories
+    if (c.subcategories) {
+      for (const sub of c.subcategories) {
+        const resultConfig = sub.items.find(v => v.config.type === view || v.config.view === view);
+        if (resultConfig && resultConfig.propEditors) {
+          return resultConfig.propEditors;
+        }
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
- item type config already had categories enabling single level menu organization, but now subcategories are added allowing to create sub-level menus

```typescript
export interface ItemTypeCategory {
  title: string,
  type: DialobCategoryType,
  items?: CategoryItem[],
  subcategories?: Subcategory[]
}

export interface Subcategory {
  title: string,
  items: CategoryItem[]
}
```

- input types passed in `items` will be rendered first, and then below a divider the `subcategories` will appear

- code is modified to account for these changes, and to be backwards compatible with existing configs

<img width="678" height="395" alt="image" src="https://github.com/user-attachments/assets/b99d38dd-fe13-439e-9a22-acce882f7c9b" />
