### PR TITLE
feat: support expression variables scoped to rowgroups

### DIFF
--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/AbstractItemBuilder.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/AbstractItemBuilder.java
@@ -34,6 +34,7 @@ import java.util.*;
 import java.util.function.Consumer;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
 
 public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<T,P>,P extends ExpressionCompiler & BuilderParent> implements Builder<P>, AliasesProvider {
 
@@ -149,8 +150,13 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<T,P>,P e
     return (T) this;
   }
 
+  @Override
   public Map<String, ItemId> getAliases() {
-    return Collections.emptyMap();
+    if (getHoistingGroup().map(groupBuilder -> groupBuilder.getType() == GroupBuilder.Type.ROWGROUP).orElse(false)) {
+      return getHoistingGroup().map(GroupBuilder::getItemIds).map(itemIds -> itemIds.stream().collect(toMap(
+        itemId -> ((ItemRef) itemId).getId(), itemId -> itemId))).orElse(Map.of());
+    }
+    return Map.of();
   }
 
   protected T setActiveWhen(Expression activeWhen) {
@@ -220,9 +226,6 @@ public abstract class AbstractItemBuilder<T extends AbstractItemBuilder<T,P>,P e
     return Optional.empty();
   }
 
-  LocalizedLabelOperator createLabelOperator(Map<String, String> label) {
-    return createLabelOperator(Label.of(label));
-  }
   LocalizedLabelOperator createLabelOperator(Label label) {
     return LocalizedLabelOperator.createLocalizedLabelOperator(getProgramBuilder(), label);
   }

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/ProgramBuilder.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/ProgramBuilder.java
@@ -171,7 +171,7 @@ public class ProgramBuilder implements ExpressionCompiler, BuilderParent, Builde
   }
 
   public VariableBuilder addVariable(String id) {
-    return queue(new VariableBuilder(this, id));
+    return queue(new VariableBuilder(this, findHoistingGroup(id).orElse(null), id));
   }
 
   public ValueSetBuilder addValueSet(String id) {
@@ -230,14 +230,17 @@ public class ProgramBuilder implements ExpressionCompiler, BuilderParent, Builde
       LOGGER.debug("Could not compile all expressions: {}", uncompiledExpressions);
       return false;
     }
-    ddrlExpressionCompiler.getAsyncFunctionVariableExpressions().forEach((key, value) -> addItem(
-      new VariableItem.Builder()
-        .id(IdUtils.toId(key))
-        .type(Constants.VARIABLE)
-        .isPrototype(false)
-        .isAsync(true)
-        .valueExpression(value)
-        .build()));
+    ddrlExpressionCompiler.getAsyncFunctionVariableExpressions().forEach((key, value) -> {
+      ItemId itemId = IdUtils.toId(key);
+      addItem(
+        new VariableItem.Builder()
+          .id(itemId)
+          .type(Constants.VARIABLE)
+          .isPrototype(itemId.isPartial())
+          .isAsync(true)
+          .valueExpression(value)
+          .build());
+    });
     return true;
   }
 

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/QuestionBuilder.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/QuestionBuilder.java
@@ -307,13 +307,4 @@ public class QuestionBuilder extends AbstractItemBuilder<QuestionBuilder,Program
     return Optional.ofNullable(defaultValue);
   }
 
-  @Override
-  public Map<String, ItemId> getAliases() {
-    Map<String, ItemId> aliases = super.getAliases();
-    if (getHoistingGroup().map(groupBuilder -> groupBuilder.getType() == GroupBuilder.Type.ROWGROUP).orElse(false)) {
-      aliases = getHoistingGroup().map(GroupBuilder::getItemIds).map(itemIds -> itemIds.stream().collect(toMap(
-        itemId -> ((ItemRef) itemId).getId(), itemId -> itemId))).orElse(aliases);
-    }
-    return aliases;
-  }
 }

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/VariableBuilder.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/VariableBuilder.java
@@ -40,8 +40,8 @@ public class VariableBuilder extends AbstractItemBuilder<GroupBuilder, ProgramBu
 
   private boolean published = false;
 
-  VariableBuilder(ProgramBuilder programBuilder, String id) {
-    super(programBuilder, programBuilder, null, id);
+  VariableBuilder(ProgramBuilder programBuilder, GroupBuilder hoistingGroupBuilder, String id) {
+    super(programBuilder, programBuilder, hoistingGroupBuilder, id);
   }
 
   public VariableBuilder setValueExpression(String valueExpression) {
@@ -107,7 +107,7 @@ public class VariableBuilder extends AbstractItemBuilder<GroupBuilder, ProgramBu
       new VariableItem.Builder()
         .id(id)
         .type(context ? Constants.CONTEXT : Constants.VARIABLE)
-        .isPrototype(false)
+        .isPrototype(getId().isPartial())
         .isPublished(this.published)
         .valueExpression(this.valueExpression)
         .defaultValue(resolvedDefaultValue.orElse(null)).build());

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/session/CreateDialobSessionProgramVisitor.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/session/CreateDialobSessionProgramVisitor.java
@@ -121,7 +121,12 @@ public class CreateDialobSessionProgramVisitor implements ProgramVisitor {
 
       @Override
       public void visitVariableItem(@NonNull VariableItem item) {
-        items.add(createItemState(item.id(), item, item.isPublished()));
+        ItemState state = createItemState(item.id(), item, item.isPublished());
+        if (item.isPrototype()) {
+          prototypeItems.add(state);
+        } else {
+          items.add(state);
+        }
       }
 
       @Override

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/session/command/VariableUpdateCommand.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/session/command/VariableUpdateCommand.java
@@ -23,13 +23,12 @@ import io.dialob.session.engine.session.model.ItemId;
 import io.dialob.session.engine.session.model.ItemState;
 
 import java.util.List;
-import java.util.Set;
 
 record VariableUpdateCommand(
   ItemId targetId,
   Expression expression,
   List<Trigger<ItemState>> triggers
-) implements AbstractUpdateCommand<ItemId,ItemState>, ItemUpdateCommand {
+) implements AbstractUpdateAttributeCommand<Object>, ItemUpdateCommand {
 
   @NonNull
   @Override
@@ -39,14 +38,8 @@ record VariableUpdateCommand(
 
   @NonNull
   @Override
-  public Set<EventMatcher> eventMatchers() {
-    return this.expression().getEvalRequiredConditions();
-  }
-
-  @NonNull
-  @Override
   public ItemState update(@NonNull EvalContext context, @NonNull ItemState itemState) {
-    final Object eval = this.expression().eval(context);
+    final Object eval = this.evalExpression(context);
     // TODO handle multiple concurrent async updates?
     if (isPending(eval)) {
       context.queueAsyncFunctionCall(

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/AbstractDialobProgramTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/AbstractDialobProgramTest.java
@@ -198,6 +198,11 @@ public abstract class AbstractDialobProgramTest {
     Assertions.assertFalse(itemState.isReadOnly());
   }
 
+  protected void assertVariableEquals(final DialobSession session, Object expected, final ItemId itemId) {
+    final ItemState itemState = session.getItemState(itemId).get();
+    Assertions.assertEquals(expected, itemState.getValue());
+  }
+
   protected void assertErrorInactive(final DialobSession session, final ItemId itemId, final String errorCode) {
     final Collection<ErrorState> errorStates = session.errorStates().values();
     for (final ErrorState errorState : errorStates) {

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/DialobProgramFromFormCompilerTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/DialobProgramFromFormCompilerTest.java
@@ -18,6 +18,7 @@ package io.dialob.session.engine;
 import io.dialob.api.form.Form;
 import io.dialob.api.form.FormItem;
 import io.dialob.api.form.Validation;
+import io.dialob.api.form.Variable;
 import io.dialob.api.proto.Action;
 import io.dialob.rule.parser.function.FunctionRegistry;
 import io.dialob.session.engine.program.DialobProgram;
@@ -28,6 +29,7 @@ import io.dialob.session.engine.session.model.ItemId;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.math.BigInteger;
 import java.util.Map;
 
 import static io.dialob.session.engine.session.ActionToCommandMapper.toCommands;
@@ -166,6 +168,73 @@ class DialobProgramFromFormCompilerTest extends AbstractDialobProgramTest {
 
     Mockito.verifyNoMoreInteractions(functionRegistry);
   }
+
+  @Test
+  void shouldCalculateExpressionVariablesInRowgroupsContext() {
+    FunctionRegistry functionRegistry = Mockito.mock(FunctionRegistry.class);
+    DialobSessionEvalContextFactory sessionContextFactory = new DialobSessionEvalContextFactory(functionRegistry, null);
+    DialobProgramFromFormCompiler compiler = new DialobProgramFromFormCompiler(functionRegistry);
+
+    DialobProgram dialobProgram = compiler.compileForm(new Form.Builder()
+      .id("123")
+      .name("123")
+      .putData("questionnaire", new FormItem.Builder()
+        .id("questionnaire")
+        .type("questionnaire")
+        .addItems("g")
+        .build())
+      .putData("g", new FormItem.Builder()
+        .id("g")
+        .type("group")
+        .addItems("rg")
+        .build())
+      .putData("rg", new FormItem.Builder()
+        .id("rg")
+        .type("rowgroup")
+        .addItems("q1","q2","q3","summa")
+        .build())
+      .putData("q1", new FormItem.Builder()
+        .id("q1")
+        .type("number")
+        .build())
+      .putData("q2", new FormItem.Builder()
+        .id("q2")
+        .type("number")
+        .build())
+      .putData("q3", new FormItem.Builder()
+        .id("q3")
+        .activeWhen("q1 + q2 > 3")
+        .type("number")
+        .build())
+      .addVariables(new Variable.Builder()
+        .name("summa")
+        .context(false)
+        .expression("q1 + q2")
+        .build())
+      .metadata(new Form.Metadata.Builder()
+        .label("xxx")
+        .putAdditionalProperties("answersRequiredByDefault", true)
+        .build())
+      .build());
+
+    DialobSession session = dialobProgram.createSession(sessionContextFactory, null, null, "fi", null);
+    assertNotNull(session);
+    DialobSessionUpdater dialobSessionUpdater = sessionContextFactory.createSessionUpdater(dialobProgram, session, false);
+
+    dialobSessionUpdater.applyCommands(toCommands(addRow(toRef("rg"))));
+    assertVariableEquals(session, null, toRef("rg.0.summa"));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q1"), "1")));
+    assertInactive(session, toRef("rg.0.q3"));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q2"), "2")));
+//    assertActive(session, toRef("rg.0.q3"));
+    assertVariableEquals(session, BigInteger.valueOf(3), toRef("rg.0.summa"));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q2"), null)));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q1"), null)));
+    assertVariableEquals(session, null, toRef("rg.0.summa"));
+
+    Mockito.verifyNoMoreInteractions(functionRegistry);
+  }
+
 
 
   @Test

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/VariableBuilderTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/VariableBuilderTest.java
@@ -32,7 +32,7 @@ class VariableBuilderTest {
     ProgramBuilder programBuilder = Mockito.mock(ProgramBuilder.class);
     String id = "id";
 
-    new VariableBuilder(programBuilder, id)
+    new VariableBuilder(programBuilder, null, id)
       .setContext(true)
       .setType("number")
       .setDefaultValue("err")
@@ -57,7 +57,7 @@ class VariableBuilderTest {
     ProgramBuilder programBuilder = Mockito.mock(ProgramBuilder.class);
     String id = "id";
 
-    new VariableBuilder(programBuilder, id)
+    new VariableBuilder(programBuilder, null, id)
       .setContext(true)
       .setDefaultValue("err")
       .afterExpressionCompilation(errorConsumer);


### PR DESCRIPTION
- Update `VariableBuilder` and `ProgramBuilder` to correctly handle variables within hoisting groups, marking them as prototypes when appropriate.
- Move alias resolution logic from `QuestionBuilder` to `AbstractItemBuilder` to support relative references in variable expressions within rowgroups.
- Update `CreateDialobSessionProgramVisitor` to register prototype variables.
- Refactor `VariableUpdateCommand` to extend `AbstractUpdateAttributeCommand`.
- Add `shouldCalculateExpressionVariablesInRowgroupsContext` test to `DialobProgramFromFormCompilerTest` to verify variable behavior in rowgroups.
- Add `assertVariableEquals` helper to `AbstractDialobProgramTest`.
- Refactor `ActionToCommandMapper.toCommands` usage to static import in `DialobProgramFromFormCompilerTest`.