### PR TITLE
Ability to sort versions

### DIFF
--- a/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
@@ -89,7 +89,7 @@ const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
 
 export const MarkdownEditor: React.FC<{ value: string, setValue: (value: string, language: string) => void, language: string }> = ({ value, setValue, language }) => {
   const theme = useTheme();
-  const editorRef = useRef<any>(null);
+  const editorRef = useRef<{ view?: EditorView }>(null);
   const [menuState, setMenuState] = useState<MenuState>(INITIAL_MENU_STATE);
 
   const applyMarkdown = useCallback((action: MarkdownAction) => {

--- a/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Box, Button, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Typography } from '@mui/material';
-import { useEditor } from '../../editor'
 import { BorderedTable } from '../TableEditorComponents';
-import { useComposer } from '../../dialob';
 import { FormattedMessage } from 'react-intl';
 import PropItem from './PropItem';
 import { useBackend } from '../../backend/useBackend';

--- a/frontend/dialob-composer-material/src/components/tree/Handle.tsx
+++ b/frontend/dialob-composer-material/src/components/tree/Handle.tsx
@@ -65,3 +65,5 @@ export const Handle = React.forwardRef<HTMLButtonElement, HandleProps>(
     );
   }
 );
+
+Handle.displayName = 'Handle';

--- a/frontend/dialob-composer-material/src/components/tree/TreeItem.tsx
+++ b/frontend/dialob-composer-material/src/components/tree/TreeItem.tsx
@@ -18,7 +18,7 @@ export interface TreeItemProps {
   disableInteraction?: boolean;
   disableSelection?: boolean;
   ghost?: boolean;
-  handleProps?: any;
+  handleProps?: React.HTMLAttributes<HTMLElement>;
   indentationWidth: number;
   id: string;
   title: string;
@@ -134,3 +134,5 @@ export const TreeItem = React.forwardRef<HTMLDivElement, TreeItemProps>((props, 
     </StyledListItem>
   )
 });
+
+TreeItem.displayName = 'TreeItem';

--- a/frontend/dialob-composer-material/src/components/tree/TreeItemComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/tree/TreeItemComponents.tsx
@@ -8,7 +8,7 @@ interface StyledProps {
 
 export const StyledListItem = styled(ListItem, {
   shouldForwardProp: (prop) => !['clone', 'ghost', 'disableInteraction'].includes(prop.toString()),
-})<StyledProps>(({ theme, clone, ghost, disableInteraction }) => ({
+})<StyledProps>(({ theme, ghost, disableInteraction }) => ({
   marginBottom: theme.spacing(-0.125),
   pointerEvents: disableInteraction ? 'none' : 'auto',
   opacity: ghost ? 0.5 : 1,

--- a/frontend/dialob-composer-material/src/defaults/markdown.tsx
+++ b/frontend/dialob-composer-material/src/defaults/markdown.tsx
@@ -14,16 +14,16 @@ export const markdownComponents: object = {
   'img': (props: { alt: string, src: string }) => <Box component="img" alt={props.alt} src={props.src} maxWidth={600} width="100%" padding="8px 0px" />,
   table: ({ children }: { children: React.ReactNode }) => (
     <TableContainer component={Paper} sx={{ my: 2 }}>
-      <Table children={children} />
+      <Table>{children}</Table>
     </TableContainer>
   ),
-  thead: ({ children }: { children: React.ReactNode }) => <TableHead children={children} />,
-  tbody: ({ children }: { children: React.ReactNode }) => <TableBody children={children} />,
-  tr: ({ children }: { children: React.ReactNode }) => <TableRow children={children} />,
+  thead: ({ children }: { children: React.ReactNode }) => <TableHead>{children}</TableHead>,
+  tbody: ({ children }: { children: React.ReactNode }) => <TableBody>{children}</TableBody>,
+  tr: ({ children }: { children: React.ReactNode }) => <TableRow>{children}</TableRow>,
   th: ({ children }: { children: React.ReactNode }) => (
-    <TableCell children={children} sx={{ fontWeight: "bold", backgroundColor: "grey.100" }} />
+    <TableCell sx={{ fontWeight: "bold", backgroundColor: "grey.100" }}>{children}</TableCell>
   ),
-  td: ({ children }: { children: React.ReactNode }) => <TableCell children={children} />,
+  td: ({ children }: { children: React.ReactNode }) => <TableCell>{children}</TableCell>,
   pre: ({ children }: { children: React.ReactNode }) => (
     <Box
       component="pre"

--- a/frontend/dialob-composer-material/src/dialogs/FormOptionsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/FormOptionsDialog.tsx
@@ -21,7 +21,7 @@ const visibilityModeOptions = [
   { value: 'ALL' as VisibilityType, label: 'dialogs.form.options.visibility.ALL' }
 ];
 
-const StyledListItem = styled(ListItem)(({ theme }) => ({
+const StyledListItem = styled(ListItem)(() => ({
   padding: 0,
 }));
 

--- a/frontend/dialob-composer-material/src/dialogs/MarkdownHelpDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/MarkdownHelpDialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useEditor } from "../editor";
 import { FormattedMessage } from "react-intl";
-import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box, Table, TableRow, TableCell, TableHead, TableContainer, TableBody, Paper } from "@mui/material";
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Box } from "@mui/material";
 import { Close } from "@mui/icons-material";
 import markdownContent from './MARKDOWN_EDITOR.md?raw';
 import Markdown from "react-markdown";
@@ -30,7 +30,7 @@ const MarkdownHelpDialog: React.FC = () => {
       </DialogTitle>
       <DialogContent sx={{ display: 'flex', borderTop: 1, borderBottom: 1, borderColor: 'divider', p: 0, height: '90vh' }}>
         <Box sx={{ p: 3, width: 1 }}>
-          <Markdown children={markdownContent} remarkPlugins={[remarkGfm]} components={markdownComponents} />
+          <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>{markdownContent}</Markdown>
         </Box>
       </DialogContent>
       <DialogActions>

--- a/frontend/dialob-composer-material/src/dialogs/UploadValuesetDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/UploadValuesetDialog.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Dialog, DialogTitle, DialogContent, Button, CircularProgress, Typography, Select, MenuItem, Alert } from "@mui/material";
 import { Help, Upload, Warning } from "@mui/icons-material";
 import { DialogActionButtons } from "./DialogComponents";
-import { useComposer } from "../dialob";
 import { ValueSet, ValueSetEntry, LocalizedString } from "../types";
 import { FormattedMessage } from "react-intl";
 import { parseCsvFile } from "../utils/ParseUtils";

--- a/frontend/dialob-composer-material/src/dialogs/VersioningDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/VersioningDialog.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {
   Dialog, DialogTitle, DialogContent, Button, DialogActions, Typography, Box,
   TableHead, TableRow, TableCell, TableBody, alpha, useTheme, IconButton,
-  Tooltip
+  Tooltip, TableSortLabel
 } from "@mui/material";
 import { Close, ContentCopy, Download, EditNote, Help, LocalOffer } from "@mui/icons-material";
 import { FormattedMessage } from "react-intl";
@@ -25,6 +25,7 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
   const docsUrl = useDocs('versioning');
   const [tags, setTags] = React.useState<ComposerTag[]>([]);
   const [tagToCopy, setTagToCopy] = React.useState<ComposerTag>();
+  const [sortOrder, setSortOrder] = React.useState<'asc' | 'desc'>('desc');
 
   const LATEST_TAG: ComposerTag = React.useMemo(() => ({
     formId: form._id + '', name: 'LATEST', formName: form.name, description: 'Latest version',
@@ -36,6 +37,18 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
       getTags(form.name).then(setTags);
     }
   }, [open]);
+
+  const handleSortChange = () => {
+    setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc');
+  };
+
+  const sortedTags = React.useMemo(() => {
+    return [LATEST_TAG, ...tags].sort((a, b) => {
+      const dateA = new Date(a.created || 0).getTime();
+      const dateB = new Date(b.created || 0).getTime();
+      return sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
+    });
+  }, [tags, sortOrder, LATEST_TAG]);
 
   const handleLoadVersion = (tag: ComposerTag) => {
     loadForm(tag.formId + '').then(form => {
@@ -100,7 +113,13 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
                     <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.description' /></Typography>
                   </TableCell>
                   <TableCell sx={{ p: 1 }}>
-                    <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.created' /></Typography>
+                    <TableSortLabel
+                      active={true}
+                      direction={sortOrder}
+                      onClick={handleSortChange}
+                    >
+                      <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.created' /></Typography>
+                    </TableSortLabel>
                   </TableCell>
                   <TableCell align='center' sx={{ p: 1 }}>
                     <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.actions' /></Typography>
@@ -108,7 +127,7 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
                 </TableRow>
               </TableHead>
               <TableBody>
-                {[LATEST_TAG, ...tags].map(tag => (
+                {sortedTags.map(tag => (
                   <TableRow key={tag.formId} sx={tag.name === 'LATEST' ? { backgroundColor: alpha(theme.palette.primary.main, 0.1) } : {}}>
                     <TableCell>
                       <Tooltip

--- a/frontend/dialob-composer-material/src/dialogs/VersioningDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/VersioningDialog.tsx
@@ -26,6 +26,7 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
   const [tags, setTags] = React.useState<ComposerTag[]>([]);
   const [tagToCopy, setTagToCopy] = React.useState<ComposerTag>();
   const [sortOrder, setSortOrder] = React.useState<'asc' | 'desc'>('desc');
+  const [sortBy, setSortBy] = React.useState<'name' | 'description' | 'created'>('created');
 
   const LATEST_TAG: ComposerTag = React.useMemo(() => ({
     formId: form._id + '', name: 'LATEST', formName: form.name, description: 'Latest version',
@@ -38,17 +39,32 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
     }
   }, [open]);
 
-  const handleSortChange = () => {
-    setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc');
+  const handleSortChange = (column: 'name' | 'description' | 'created') => {
+    if (sortBy === column) {
+      setSortOrder(prev => prev === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(column);
+      setSortOrder('asc');
+    }
   };
 
   const sortedTags = React.useMemo(() => {
     return [LATEST_TAG, ...tags].sort((a, b) => {
-      const dateA = new Date(a.created || 0).getTime();
-      const dateB = new Date(b.created || 0).getTime();
-      return sortOrder === 'asc' ? dateA - dateB : dateB - dateA;
+      let compareValue = 0;
+      
+      if (sortBy === 'name') {
+        compareValue = (a.name || '').localeCompare(b.name || '');
+      } else if (sortBy === 'description') {
+        compareValue = (a.description || '').localeCompare(b.description || '');
+      } else { // created
+        const dateA = new Date(a.created || 0).getTime();
+        const dateB = new Date(b.created || 0).getTime();
+        compareValue = dateA - dateB;
+      }
+      
+      return sortOrder === 'asc' ? compareValue : -compareValue;
     });
-  }, [tags, sortOrder, LATEST_TAG]);
+  }, [tags, sortOrder, sortBy, LATEST_TAG]);
 
   const handleLoadVersion = (tag: ComposerTag) => {
     loadForm(tag.formId + '').then(form => {
@@ -107,16 +123,28 @@ const VersioningDialog: React.FC<{ open: boolean, onClose: () => void }> = ({ op
               <TableHead>
                 <TableRow>
                   <TableCell sx={{ p: 1 }}>
-                    <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.name' /></Typography>
-                  </TableCell>
-                  <TableCell sx={{ p: 1 }}>
-                    <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.description' /></Typography>
+                    <TableSortLabel
+                      active={sortBy === 'name'}
+                      direction={sortOrder}
+                      onClick={() => handleSortChange('name')}
+                    >
+                      <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.name' /></Typography>
+                    </TableSortLabel>
                   </TableCell>
                   <TableCell sx={{ p: 1 }}>
                     <TableSortLabel
-                      active={true}
+                      active={sortBy === 'description'}
                       direction={sortOrder}
-                      onClick={handleSortChange}
+                      onClick={() => handleSortChange('description')}
+                    >
+                      <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.description' /></Typography>
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell sx={{ p: 1 }}>
+                    <TableSortLabel
+                      active={sortBy === 'created'}
+                      direction={sortOrder}
+                      onClick={() => handleSortChange('created')}
                     >
                       <Typography fontWeight='bold'><FormattedMessage id='dialogs.versioning.list.header.created' /></Typography>
                     </TableSortLabel>

--- a/frontend/dialob-composer-material/src/items/ItemFactory.tsx
+++ b/frontend/dialob-composer-material/src/items/ItemFactory.tsx
@@ -16,7 +16,7 @@ const itemFactory = (item: DialobItem, itemConfig: ItemConfig, setHighlightedIte
   const onClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     scrollToTreeItem(item.id);
-    setHighlightedItem && setHighlightedItem(item);
+    setHighlightedItem?.(item);
   }
 
   const Component = matchedConfig.component;

--- a/frontend/dialob-composer-material/src/items/Note.tsx
+++ b/frontend/dialob-composer-material/src/items/Note.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Paper, Table, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
+import { Paper, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
 import { Element } from 'react-scroll';
 import { DialobItem } from '../types';
 import { ConversionMenu, IdField, Indicators, NoteField, OptionsMenu, StyledTable } from './ItemComponents';

--- a/frontend/dialob-composer-material/src/items/SimpleField.tsx
+++ b/frontend/dialob-composer-material/src/items/SimpleField.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Paper, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme, Theme } from '@mui/material';
+import { Paper, TableBody, TableCell, TableContainer, TableRow, alpha, useTheme } from '@mui/material';
 import { Element } from 'react-scroll';
 import { DialobItem } from '../types';
 import { ConversionMenu, IdField, LabelField, Indicators, OptionsMenu, VisibilityField, StyledTable } from './ItemComponents';


### PR DESCRIPTION
- versions/tags can now be sorted in the versioning dialog - by name, description or creation date, in ascending or descending order

<img width="911" height="411" alt="image" src="https://github.com/user-attachments/assets/91b3bd56-974f-4e42-b9ed-9770fe1cb905" />

- fixed linter errors
