### PR TITLE
Improved empty string handling and clearing values

### DIFF
--- a/frontend/dialob-composer-material/docs/EMPTY_STRING_HANDLING.md
+++ b/frontend/dialob-composer-material/docs/EMPTY_STRING_HANDLING.md
@@ -1,0 +1,57 @@
+# Empty String and Undefined Handling
+
+This document describes how the Dialob Composer distinguishes between empty strings and undefined values.
+
+## Core Principle
+
+- **Empty string (`''`)**: Valid value that can be stored in the data model
+- **Undefined**: Missing value, triggers key deletion from the data model
+- **Clear button**: Explicitly sets value to `undefined` to delete it
+
+## Clear Button Behavior
+
+All optional input fields show a clear button (X icon) when `value !== undefined`. Clicking it sets the value to `undefined`, which triggers deletion of the key from the data object.
+
+## Missing Value Detection
+
+**Translation detection**: Both `undefined` and `''` are considered missing translations.
+
+**Backend validation**: Both `undefined` and `''` should be treated as missing for required fields such as variable expressions.
+
+## UI Components
+
+### `TextEditorWithClear`
+Wraps MUI `TextField` with inline clear button. Used for: descriptions, default values.
+
+### `CodeEditorWithClear`
+Wraps CodeMirror editors with overlaid clear button. Used for: expressions, rules, validation rules, markdown.
+
+### Localized Fields
+Each language has its own clear button that removes that specific language key. Used in: labels, descriptions, validation messages, valueset entry labels.
+
+### Component State
+Components initialize state as `string | undefined` and handle both empty strings and undefined values. The clear button always sets state to `undefined`.
+
+## Type Signatures
+
+All clearable fields accept `string | undefined`:
+- `updateExpressionVariable(variableId, expression)`
+- `updateVariableDescription(variableId, description)`
+- `setValidationExpression(itemId, index, expression)`
+- `updateValueSetEntryLabel(valueSetId, index, text, language)`
+- `updateItem(itemId, attribute, value, language?)`
+
+## Fields With Clear Buttons
+
+**Text fields**: Item default values, variable descriptions, variable default values
+**Code fields**: Variable expressions, rules (visibility, requirement, readonly, canaddrow, canremoverow), validation expressions
+**Localized fields**: Item labels, descriptions, validation messages, valueset entry labels, markdown content
+
+## Quick Reference
+
+| Component | Clear Action | State Type |
+|-----------|--------------|------------|
+| TextEditorWithClear | Sets `undefined` | `string \| undefined` |
+| CodeEditorWithClear | Sets `undefined` | `string \| undefined` |
+| Localized clear buttons | Deletes language key | Per-language |
+| Missing detection | Checks both `undefined` and `''` | Translation/validation |

--- a/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
@@ -103,6 +103,16 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
     setLocalizedString(prev => ({ ...prev, [language]: value }));
   }
 
+  const handleClearLanguage = (language: string) => {
+    const updated = { ...localizedString };
+    delete updated[language];
+    setLocalizedString(updated);
+    onTextEdit(entry, updated);
+    if (isAITranslated(language)) {
+      removeFlag(language);
+    }
+  };
+
   const handleBlurText = (language: string) => {
     const currentValue = localizedString[language] || '';
     const originalValue = entry.label?.[language] || '';
@@ -222,7 +232,7 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
                 }} />
             </TableCell>
             {formLanguages?.map(lang => {
-              const hasValue = localizedString && localizedString[lang];
+              const hasValue = localizedString && localizedString[lang] !== undefined;
               const sourceLanguage = editor.activeFormLanguage;
               const hasSourceValue = localizedString && localizedString[sourceLanguage];
               const canTranslate = !hasValue && hasSourceValue && lang !== sourceLanguage && config.translationServiceUrl;
@@ -240,6 +250,20 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
                       onChange={(e) => handleUpdate(e.target.value, lang)}
                       onBlur={() => handleBlurText(lang)}
                     />
+                    {hasValue && (
+                      <Tooltip title={<FormattedMessage id="buttons.clear" />}>
+                        <span>
+                          <IconButton
+                            disabled={!hasValue}
+                            onClick={() => handleClearLanguage(lang)}
+                            size="small"
+                            sx={{ p: 0.25 }}
+                          >
+                            <Close fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    )}
                     {canTranslate && (
                       <TranslateButton
                         sourceLanguage={sourceLanguage}

--- a/frontend/dialob-composer-material/src/components/ErrorComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/ErrorComponents.tsx
@@ -42,7 +42,7 @@ const extractCodeFromItem = (item: DialobItem, start: number, end: number, type:
 }
 
 const extractCodeFromVariable = (variable: Variable, start: number, end: number) => {
-  return variable.expression.substring(start, end + 1);
+  return variable.expression?.substring(start, end + 1) ?? '';
 }
 
 const extractListError = (valueSet: ValueSet, index: number) => {

--- a/frontend/dialob-composer-material/src/components/code/CodeEditorWithClear.tsx
+++ b/frontend/dialob-composer-material/src/components/code/CodeEditorWithClear.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Box, IconButton, Tooltip } from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { FormattedMessage } from 'react-intl';
+
+export interface CodeEditorWithClearProps {
+  value: string | undefined;
+  onClear: () => void;
+  children: React.ReactNode;
+}
+
+export const CodeEditorWithClear: React.FC<CodeEditorWithClearProps> = ({ 
+  value, 
+  onClear, 
+  children,
+}) => {
+  const shouldShowClear = value !== undefined;
+
+  return (
+    <Box sx={{ 
+      display: 'flex', 
+      alignItems: 'center',
+      gap: 0.5
+    }}>
+      <Box sx={{ flexGrow: 1 }}>
+        {children}
+      </Box>
+      <Tooltip title={<FormattedMessage id="buttons.clear" />}>
+        <span>
+          <IconButton
+            disabled={!shouldShowClear}
+            onClick={onClear}
+            size="small"
+          >
+            <Close fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </Box>
+  );
+};

--- a/frontend/dialob-composer-material/src/components/editors/DefaultValueEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/DefaultValueEditor.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, TextField, Typography } from "@mui/material";
+import { Alert, Box, Typography } from "@mui/material";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import { useEditor } from "../../editor";
@@ -6,6 +6,7 @@ import { getErrorSeverity } from "../../utils/ErrorUtils";
 import { Warning } from "@mui/icons-material";
 import { ErrorMessage } from "../ErrorComponents";
 import { useSave } from "../../dialogs/contexts/saving/useSave";
+import { TextEditorWithClear } from "./TextEditorWithClear";
 
 const DefaultValueEditor: React.FC = () => {
   const { savingState, updateItem } = useSave();
@@ -23,10 +24,19 @@ const DefaultValueEditor: React.FC = () => {
     }
   }
 
+  const handleClear = () => {
+    updateItem(item.id, 'defaultValue', undefined);
+  };
+
   return (
     <Box>
       <Typography color="text.hint"><FormattedMessage id='dialogs.options.default' /></Typography>
-      <TextField variant='outlined' value={item.defaultValue || ''} onChange={(e) => handleUpdate(e.target.value)} />
+      <TextEditorWithClear 
+        variant='outlined' 
+        value={item.defaultValue} 
+        onChange={handleUpdate}
+        onClear={handleClear}
+      />
       {itemErrors?.map((error, index) => <Alert key={index} severity={getErrorSeverity(error)} sx={{ mt: 2 }} icon={<Warning />}>
         <Typography color={error.level.toLowerCase()}><ErrorMessage error={error} /></Typography>
       </Alert>)}

--- a/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
@@ -153,7 +153,7 @@ const LocalizedStringEditor: React.FC<{
         const localizedText = localizedString?.[language];
         const isTranslating = translating[language];
         const canTranslate = language !== activeFormLanguage && 
-                            !localizedText && 
+                            localizedText === undefined && 
                             localizedString?.[activeFormLanguage] &&
                             config.translationServiceUrl;
         const aiMetadata = isAITranslated(language) ? getAITranslationMetadata(language) : null;

--- a/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/LocalizedStringEditor.tsx
@@ -72,6 +72,23 @@ const LocalizedStringEditor: React.FC<{
     }
   }
 
+  const handleClearLanguage = (language: string) => {
+    const updatedLocalizedString: LocalizedString = { ...localizedString };
+    delete updatedLocalizedString[language];
+    
+    if (isAITranslated(language)) {
+      removeFlag(language);
+    }
+
+    if (type === 'validations' && rule && setRule) {
+      const newRule = { ...rule, validationRule: { ...rule.validationRule, message: updatedLocalizedString } };
+      setRule(newRule);
+      updateLocalizedString(item.id, type, updatedLocalizedString, rule.index);
+    } else {
+      updateLocalizedString(item.id, type, updatedLocalizedString);
+    }
+  }
+
   const handleTranslate = async (targetLanguage: string) => {
     if (!config.translationServiceUrl) {
       console.error('Translation service URL not configured');
@@ -133,7 +150,7 @@ const LocalizedStringEditor: React.FC<{
         </Button>
       </Box>
       {formLanguages?.map((language) => {
-        const localizedText = localizedString ? localizedString[language] : '';
+        const localizedText = localizedString?.[language];
         const isTranslating = translating[language];
         const canTranslate = language !== activeFormLanguage && 
                             !localizedText && 
@@ -162,7 +179,7 @@ const LocalizedStringEditor: React.FC<{
             </Box>
             <Box sx={{ border: 1, borderRadius: 1, borderColor: 'divider', my: 1 }}>
               {preview ? <Markdown components={markdownComponents} remarkPlugins={[remarkGfm]}>{localizedText}</Markdown> :
-              <MarkdownEditor value={localizedText} setValue={handleUpdate} language={language} />}
+              <MarkdownEditor value={localizedText} setValue={handleUpdate} language={language} onClear={handleClearLanguage} />}
             </Box>
           </Box>
         );

--- a/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/MarkdownEditor.tsx
@@ -7,6 +7,7 @@ import { markdown } from '@codemirror/lang-markdown';
 import { EditorView } from '@codemirror/view';
 import Markdown from 'react-markdown';
 import { markdownComponents } from "../../defaults/markdown";
+import { CodeEditorWithClear } from '../code/CodeEditorWithClear';
 
 type MarkdownAction = { type: "wrap"; before: string; after: string } | { type: "insert"; text: string };
 
@@ -87,7 +88,12 @@ const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   { key: '6', ctrl: true, text: '###### ' },
 ];
 
-export const MarkdownEditor: React.FC<{ value: string, setValue: (value: string, language: string) => void, language: string }> = ({ value, setValue, language }) => {
+export const MarkdownEditor: React.FC<{ 
+  value: string | undefined, 
+  setValue: (value: string, language: string) => void, 
+  language: string,
+  onClear: (language: string) => void
+}> = ({ value, setValue, language, onClear }) => {
   const theme = useTheme();
   const editorRef = useRef<{ view?: EditorView }>(null);
   const [menuState, setMenuState] = useState<MenuState>(INITIAL_MENU_STATE);
@@ -274,44 +280,50 @@ export const MarkdownEditor: React.FC<{ value: string, setValue: (value: string,
     }
   };
 
+  const handleClear = () => {
+    onClear(language);
+  };
+
   return (
     <Box sx={{ my: 1 }}>
-      <CodeMirror
-        ref={editorRef}
-        value={value}
-        onChange={(val: string) => setValue(val || '', language)}
-        extensions={[
-          markdown({
-            completeHTMLTags: false
-          }),
-          EditorView.lineWrapping,
-          EditorView.theme({
-            '&': {
-              fontSize: theme.typography.body1.fontSize || '15px',
-            },
-            '.cm-activeLine': {
-              backgroundColor: 'transparent',
-            },
-            '.cm-activeLineGutter': {
-              backgroundColor: 'transparent',
-            }
-          })
-        ]}
-        basicSetup={{
-          lineNumbers: false,
-          foldGutter: false,
-          dropCursor: false,
-          allowMultipleSelections: false,
-          indentOnInput: true,
-          bracketMatching: true,
-          closeBrackets: true,
-          autocompletion: false,
-          highlightSelectionMatches: false,
-          searchKeymap: false,
-        }}
-        onContextMenu={handleContextMenu}
-        onKeyDown={handleKeyDown}
-      />
+      <CodeEditorWithClear value={value} onClear={handleClear}>
+        <CodeMirror
+          ref={editorRef}
+          value={value ?? ''}
+          onChange={(val: string) => setValue(val, language)}
+          extensions={[
+            markdown({
+              completeHTMLTags: false
+            }),
+            EditorView.lineWrapping,
+            EditorView.theme({
+              '&': {
+                fontSize: theme.typography.body1.fontSize || '15px',
+              },
+              '.cm-activeLine': {
+                backgroundColor: 'transparent',
+              },
+              '.cm-activeLineGutter': {
+                backgroundColor: 'transparent',
+              }
+            })
+          ]}
+          basicSetup={{
+            lineNumbers: false,
+            foldGutter: false,
+            dropCursor: false,
+            allowMultipleSelections: false,
+            indentOnInput: true,
+            bracketMatching: true,
+            closeBrackets: true,
+            autocompletion: false,
+            highlightSelectionMatches: false,
+            searchKeymap: false,
+          }}
+          onContextMenu={handleContextMenu}
+          onKeyDown={handleKeyDown}
+        />
+      </CodeEditorWithClear>
 
       <Menu
         open={menuState.anchor !== null}

--- a/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/PropertiesEditor.tsx
@@ -13,12 +13,14 @@ const PropertiesEditor: React.FC = () => {
   const { savingState, setItemProp, deleteItemProp } = useSave();
   const { config } = useBackend();
   const item = savingState.item;
-  const [props, setProps] = React.useState<ItemProp[]>([]);
+  const [props, setProps] = React.useState<ItemProp[] | undefined>(undefined);
   const [newProp, setNewProp] = React.useState<string>('');
 
   React.useEffect(() => {
     if (item?.props) {
       setProps(Object.entries(item.props).map(([key, value]) => ({ key, value })));
+    } else {
+      setProps(undefined);
     }
   }, [item?.props]);
 
@@ -58,7 +60,7 @@ const PropertiesEditor: React.FC = () => {
           <Typography sx={{ px: 2 }}><FormattedMessage id='dialogs.options.properties.add.short' /></Typography>
         </Button>
       </Box>
-      {props.length > 0 && <TableContainer>
+      {props && props.length > 0 && <TableContainer>
         <BorderedTable>
           <TableHead>
             <TableRow>

--- a/frontend/dialob-composer-material/src/components/editors/RuleEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/RuleEditor.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_ITEMTYPE_CONFIG } from '../../defaults';
 import { useBackend } from '../../backend/useBackend';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
 import { getCategoryItems } from '../../utils/ConfigUtils';
+import { CodeEditorWithClear } from '../code/CodeEditorWithClear';
 
 type RuleType = 'visibility' | 'requirement' | 'readOnly' | 'canaddrow' | 'canremoverow';
 
@@ -38,6 +39,12 @@ const RuleEditor: React.FC<{ type: RuleType }> = ({ type }) => {
     }
   }
 
+  const handleClear = () => {
+    if (item) {
+      updateItem(item.id, resolveRulePropName(type), undefined);
+    }
+  };
+
   if (!item) {
     return null;
   }
@@ -54,9 +61,9 @@ const RuleEditor: React.FC<{ type: RuleType }> = ({ type }) => {
   return (
     <Box sx={{ mb: 2 }}>
       <Typography color='text.hint'><FormattedMessage id={`dialogs.options.rules.${type}`} /></Typography>
-      <Box>
+      <CodeEditorWithClear value={item[resolveRulePropName(type)]} onClear={handleClear}>
         <CodeMirror value={item[resolveRulePropName(type)] || ''} onChange={handleUpdate} errors={itemErrors} />
-      </Box>
+      </CodeEditorWithClear>
       {itemErrors?.map((error, index) => <Alert key={index} severity={getErrorSeverity(error)} sx={{ mt: 2 }} icon={<Warning />}>
         <Typography color={error.level.toLowerCase()}><ErrorMessage error={error} /></Typography>
       </Alert>)}

--- a/frontend/dialob-composer-material/src/components/editors/TextEditorWithClear.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/TextEditorWithClear.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { TextField, IconButton, TextFieldProps, Tooltip } from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { FormattedMessage } from 'react-intl';
+
+export interface TextEditorWithClearProps extends Omit<TextFieldProps, 'value' | 'onChange' | 'onClear'> {
+  value: string | undefined;
+  onChange: (value: string) => void;
+  onClear?: () => void;
+}
+
+export const TextEditorWithClear: React.FC<TextEditorWithClearProps> = ({
+  value,
+  onChange,
+  onClear,
+  InputProps,
+  ...props
+}) => {
+  const handleClear = () => {
+    if (onClear) {
+      onClear();
+    }
+  };
+
+  const shouldShowClear = onClear && value !== undefined;
+
+  return (
+    <TextField
+      {...props}
+      value={value ?? ''}
+      onChange={(e) => onChange(e.target.value)}
+      InputProps={{
+        ...InputProps,
+        endAdornment: (
+          <Tooltip title={<FormattedMessage id="buttons.clear" />}>
+            <span>
+              <IconButton
+                onClick={handleClear}
+                disabled={!shouldShowClear}
+                size="small"
+              >
+                <Close fontSize="small" />
+              </IconButton>
+            </span>
+          </Tooltip>
+        ),
+      }}
+    />
+  );
+};

--- a/frontend/dialob-composer-material/src/components/editors/ValidationRuleEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/ValidationRuleEditor.tsx
@@ -9,6 +9,7 @@ import CodeMirror from '../code/CodeMirror';
 import { getErrorSeverity } from '../../utils/ErrorUtils';
 import { IndexedRule } from './types';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
+import { CodeEditorWithClear } from '../code/CodeEditorWithClear';
 
 const ValidationRuleEditor: React.FC = () => {
   const { editor } = useEditor();
@@ -59,6 +60,13 @@ const ValidationRuleEditor: React.FC = () => {
     }
   }
 
+  const handleClear = () => {
+    if (item && activeRule) {
+      setValidationExpression(item.id, activeRule.index, undefined);
+      setActiveRule({ ...activeRule, validationRule: { ...activeRule.validationRule, rule: undefined } });
+    }
+  };
+
   return (
     <>
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -83,7 +91,9 @@ const ValidationRuleEditor: React.FC = () => {
         </Button>
       </Box>
       {rules.length > 0 && activeRule !== undefined && <Box sx={{ mt: 2 }}>
-        <CodeMirror value={activeRule.validationRule.rule ?? ''} onChange={handleUpdate} errors={itemErrors} />
+        <CodeEditorWithClear value={activeRule.validationRule.rule} onClear={handleClear}>
+          <CodeMirror value={activeRule.validationRule.rule ?? ''} onChange={handleUpdate} errors={itemErrors} />
+        </CodeEditorWithClear>
       </Box>}
       {itemErrors?.map((error, index) => <Alert key={index} severity={getErrorSeverity(error)} sx={{ mt: 2 }} icon={<Warning />}>
         <Typography color={error.level.toLowerCase()}><ErrorMessage error={error} /></Typography>

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
@@ -56,8 +56,8 @@ const ExpressionVariableRow: React.FC<VariableProps> = ({ index, item, onClose }
         </TableCell>
         <TableCell width='25%' sx={{ p: 1 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            {variable.expression.substring(0, 20) + (variable.expression.length > 20 ? '...' : '')}
-            <IconButton><Edit color={expanded ? 'primary' : 'inherit'} onClick={() => setExpanded(!expanded)} /></IconButton>
+            {variable.expression && (variable.expression.substring(0, 20) + (variable.expression.length > 20 ? '...' : ''))}
+            <IconButton onClick={() => setExpanded(!expanded)}><Edit color={expanded ? 'primary' : 'inherit'} /></IconButton>
           </Box>
         </TableCell>
         <TableCell width='20%' sx={{ p: 1 }}>

--- a/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
@@ -8,11 +8,13 @@ import { FormattedMessage } from 'react-intl';
 import { matchItemByKeyword } from '../../utils/SearchUtils';
 import CodeMirror from '../code/CodeMirror';
 import { validateId } from '../../utils/ValidateUtils';
+import { CodeEditorWithClear } from '../code/CodeEditorWithClear';
 import { useBackend } from '../../backend/useBackend';
 import { ChangeIdResult } from '../../backend/types';
 import { ContextVariable, ContextVariableType, DialobItem, Variable } from '../../types';
 import { useComposer } from '../../dialob';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
+import { TextEditorWithClear } from '../editors/TextEditorWithClear';
 
 const VARIABLE_TYPES: ContextVariableType[] = [
   'text',
@@ -117,18 +119,26 @@ export const DescriptionField: React.FC<{ variable: Variable | ContextVariable }
   const [description, setDescription] = React.useState<string | undefined>(variable.description);
 
   const handleBlur = () => {
-    if (description && description !== variable.description) {
+    if (description !== variable.description) {
       updateVariableDescription(variable.name, description);
     }
   }
 
+  const handleClear = () => {
+    setDescription(undefined);
+    updateVariableDescription(variable.name, undefined);
+  };
+
   return (
-    <TextField
-      value={description || ''}
-      onChange={(e) => setDescription(e.target.value)}
+    <TextEditorWithClear
+      value={description}
+      onChange={(value) => setDescription(value)}
       onBlur={handleBlur}
       variant='standard'
-      InputProps={{ disableUnderline: true }}
+      InputProps={{ 
+        disableUnderline: true,
+      }}
+      onClear={handleClear}
       inputProps={{ maxLength: MAX_VARIABLE_DESCRIPTION_LENGTH }}
       fullWidth
     />
@@ -176,7 +186,7 @@ export const ContextTypeMenu: React.FC<{ variable: ContextVariable }> = ({ varia
 
 export const DefaultValueField: React.FC<{ variable: ContextVariable }> = ({ variable }) => {
   const { updateContextVariable } = useSave();
-  const [defaultValue, setDefaultValue] = React.useState<string>(variable.defaultValue);
+  const [defaultValue, setDefaultValue] = React.useState<string | undefined>(variable.defaultValue);
 
   const handleBlur = () => {
     if (defaultValue !== variable.defaultValue) {
@@ -185,17 +195,20 @@ export const DefaultValueField: React.FC<{ variable: ContextVariable }> = ({ var
   }
 
   const handleClear = () => {
-    setDefaultValue('');
-    updateContextVariable(variable.name, undefined, '');
+    setDefaultValue(undefined);
+    updateContextVariable(variable.name, undefined, undefined);
   }
 
   return (
-    <TextField
-      value={defaultValue || ''}
-      onChange={(e) => setDefaultValue(e.target.value)}
+    <TextEditorWithClear
+      value={defaultValue}
+      onChange={(value) => setDefaultValue(value)}
       onBlur={handleBlur}
       variant='standard'
-      InputProps={{ disableUnderline: true, endAdornment: <IconButton onClick={handleClear}><Close /></IconButton> }}
+      InputProps={{ 
+        disableUnderline: true, 
+      }}
+      onClear={handleClear}
       fullWidth
     />
   );
@@ -203,7 +216,7 @@ export const DefaultValueField: React.FC<{ variable: ContextVariable }> = ({ var
 
 export const ExpressionField: React.FC<{ variable: Variable, errors?: EditorError[] }> = ({ variable, errors }) => {
   const { updateExpressionVariable } = useSave();
-  const [expression, setExpression] = React.useState<string>(variable.expression);
+  const [expression, setExpression] = React.useState<string | undefined>(variable.expression);
 
   const handleBlur = () => {
     if (expression !== variable.expression) {
@@ -211,9 +224,16 @@ export const ExpressionField: React.FC<{ variable: Variable, errors?: EditorErro
     }
   }
 
+  const handleClear = () => {
+    setExpression(undefined);
+    updateExpressionVariable(variable.name, undefined);
+  };
+
   return (
     <Box sx={{ p: 1 }}>
-      <CodeMirror value={expression ?? ''} onChange={(e) => setExpression(e)} onBlur={handleBlur} errors={errors} />
+      <CodeEditorWithClear value={expression} onClear={handleClear}>
+        <CodeMirror value={expression ?? ''} onChange={(e) => setExpression(e)} onBlur={handleBlur} errors={errors} />
+      </CodeEditorWithClear>
     </Box>
   );
 }

--- a/frontend/dialob-composer-material/src/dialob/actions.ts
+++ b/frontend/dialob-composer-material/src/dialob/actions.ts
@@ -22,14 +22,14 @@ export type ComposerAction =
 
   | { type: 'createValidation', itemId: string, rule?: ValidationRule }
   | { type: 'setValidationMessage', itemId: string, index: number, language: string, message: string }
-  | { type: 'setValidationExpression', itemId: string, index: number, expression: string }
+  | { type: 'setValidationExpression', itemId: string, index: number, expression: string | undefined }
   | { type: 'deleteValidation', itemId: string, index: number }
 
   | { type: 'createValueSet', itemId: string | null, entries?: ValueSetEntry[] }
   | { type: 'setValueSetEntries', valueSetId: string, entries: ValueSetEntry[] }
   | { type: 'addValueSetEntry', valueSetId: string, entry?: ValueSetEntry }
   | { type: 'updateValueSetEntry', valueSetId: string, index: number, entry: ValueSetEntry }
-  | { type: 'updateValueSetEntryLabel', valueSetId: string, index: number, text: string | null, language: string }
+  | { type: 'updateValueSetEntryLabel', valueSetId: string, index: number, text: string | null | undefined, language: string }
   | { type: 'deleteValueSetentry', valueSetId: string, index: number }
   | { type: 'moveValueSetEntry', valueSetId: string, from: number, to: number }
   | { type: 'setGlobalValueSetName', valueSetId: string, name: string }
@@ -44,9 +44,9 @@ export type ComposerAction =
   | { type: 'createScopedExpressionVariable', rowgroupId: string, callbacks?: ComposerCallbacks }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | { type: 'updateContextVariable', variableId: string, contextType?: ContextVariableType | string, defaultValue?: any }
-  | { type: 'updateExpressionVariable', variableId: string, expression: string }
+  | { type: 'updateExpressionVariable', variableId: string, expression: string | undefined }
   | { type: 'updateVariablePublishing', variableId: string, published: boolean }
-  | { type: 'updateVariableDescription', variableId: string, description: string }
+  | { type: 'updateVariableDescription', variableId: string, description: string | undefined }
   | { type: 'deleteVariable', variableId: string }
   | { type: 'moveVariable', origin: ContextVariable | Variable, destination: ContextVariable | Variable }
 

--- a/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
+++ b/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
@@ -15,7 +15,8 @@ export const useComposer = () => {
     dispatch({ type: 'addItem', config: itemTemplate, parentItemId, afterItemId, callbacks });
   };
 
-  const updateItem = (itemId: string, attribute: string, value: string, language?: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updateItem = (itemId: string, attribute: string, value: any, language?: string) => {
     dispatch({ type: 'updateItem', itemId, attribute, value, language });
   };
 
@@ -134,7 +135,7 @@ export const useComposer = () => {
     dispatch({ type: 'updateVariablePublishing', variableId, published });
   }
 
-  const updateVariableDescription = (variableId: string, description: string) => {
+  const updateVariableDescription = (variableId: string, description: string | undefined) => {
     dispatch({ type: 'updateVariableDescription', variableId, description });
   }
 

--- a/frontend/dialob-composer-material/src/dialob/reducer.ts
+++ b/frontend/dialob-composer-material/src/dialob/reducer.ts
@@ -80,7 +80,7 @@ const updateItem = (state: ComposerState, itemId: string, attribute: string, val
       state.data[itemId][attribute][language] = cleanedValue;
     }
   } else {
-    if (value === '') {
+    if (value === undefined) {
       delete state.data[itemId][attribute];
     } else {
       state.data[itemId][attribute] = value;
@@ -253,7 +253,7 @@ const setValidationMessage = (state: ComposerState, itemId: string, index: numbe
   }
 }
 
-const setValidationExpression = (state: ComposerState, itemId: string, index: number, expression: string): void => {
+const setValidationExpression = (state: ComposerState, itemId: string, index: number, expression: string | undefined): void => {
   const validations = state.data[itemId].validations;
   if (validations) {
     const rule = validations[index];
@@ -403,12 +403,16 @@ const updateValueSetEntry = (state: ComposerState, valueSetId: string, index: nu
   }
 }
 
-const updateValueSetEntryLabel = (state: ComposerState, valueSetId: string, index: number, text: string | null, language: string): void => {
+const updateValueSetEntryLabel = (state: ComposerState, valueSetId: string, index: number, text: string | null | undefined, language: string): void => {
   if (state.valueSets) {
     const vsIdx = state.valueSets.findIndex(vs => vs.id === valueSetId);
-    if (vsIdx > -1 && text !== null && state.valueSets[vsIdx].entries !== undefined && state.valueSets[vsIdx].entries![index] !== undefined && state.valueSets[vsIdx].entries![index].label !== undefined) {
-      const cleanedText = cleanString(text);
-      state.valueSets[vsIdx].entries![index].label[language] = cleanedText;
+    if (vsIdx > -1 && state.valueSets[vsIdx].entries !== undefined && state.valueSets[vsIdx].entries![index] !== undefined && state.valueSets[vsIdx].entries![index].label !== undefined) {
+      if (text === null || text === undefined) {
+        delete state.valueSets[vsIdx].entries![index].label[language];
+      } else {
+        const cleanedText = cleanString(text);
+        state.valueSets[vsIdx].entries![index].label[language] = cleanedText;
+      }
     }
   }
 }
@@ -575,7 +579,7 @@ const updateContextVariable = (state: ComposerState, variableId: string, context
   }
 }
 
-const updateExpressionVariable = (state: ComposerState, variableId: string, expression: string): void => {
+const updateExpressionVariable = (state: ComposerState, variableId: string, expression: string | undefined): void => {
   if (state.variables) {
     const varIdx = state.variables.findIndex(v => !isContextVariable(v) && v.name === variableId);
     if (varIdx > -1) {
@@ -612,7 +616,7 @@ const updateVariablePublishing = (state: ComposerState, variableId: string, publ
   }
 }
 
-const updateVariableDescription = (state: ComposerState, variableId: string, description: string): void => {
+const updateVariableDescription = (state: ComposerState, variableId: string, description: string | undefined): void => {
   if (state.variables) {
     const varIdx = state.variables.findIndex(v => v.name === variableId);
     if (varIdx > -1) {

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingAction.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingAction.ts
@@ -7,7 +7,8 @@ import {
 import { TranslationResult } from "../../../backend/types";
 
 export type SavingAction =
-  { type: 'updateItem', itemId: string, attribute: string, value: string, language?: string }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  { type: 'updateItem', itemId: string, attribute: string, value: any, language?: string }
   | { type: 'updateItemId', itemId: string }
   | { type: 'updateLocalizedString', itemId: string, attribute: string, value: LocalizedString, index?: number }
   | { type: 'changeItemType', itemId: string, config: DialobItemTemplate }
@@ -17,14 +18,14 @@ export type SavingAction =
 
   | { type: 'createValidation', itemId: string, rule?: ValidationRule }
   | { type: 'setValidationMessage', itemId: string, index: number, language: string, message: string }
-  | { type: 'setValidationExpression', itemId: string, index: number, expression: string }
+  | { type: 'setValidationExpression', itemId: string, index: number, expression: string | undefined }
   | { type: 'deleteValidation', itemId: string, index: number }
 
   | { type: 'createValueSet', itemId: string | null, entries?: ValueSetEntry[] }
   | { type: 'setValueSetEntries', valueSetId: string, entries: ValueSetEntry[] }
   | { type: 'addValueSetEntry', valueSetId: string, entry?: ValueSetEntry }
   | { type: 'updateValueSetEntry', valueSetId: string, index: number, entry: ValueSetEntry }
-  | { type: 'updateValueSetEntryLabel', valueSetId: string, index: number, text: string | null, language: string }
+  | { type: 'updateValueSetEntryLabel', valueSetId: string, index: number, text: string | null | undefined, language: string }
   | { type: 'deleteValueSetentry', valueSetId: string, index: number }
   | { type: 'moveValueSetEntry', valueSetId: string, from: number, to: number }
   | { type: 'setGlobalValueSetName', valueSetId: string, name: string }
@@ -34,9 +35,9 @@ export type SavingAction =
   | { type: 'createVariable', context: boolean }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | { type: 'updateContextVariable', variableId: string, contextType?: ContextVariableType | string, defaultValue?: any }
-  | { type: 'updateExpressionVariable', variableId: string, expression: string }
+  | { type: 'updateExpressionVariable', variableId: string, expression: string | undefined }
   | { type: 'updateVariablePublishing', variableId: string, published: boolean }
-  | { type: 'updateVariableDescription', variableId: string, description: string }
+  | { type: 'updateVariableDescription', variableId: string, description: string | undefined }
   | { type: 'deleteVariable', variableId: string }
   | { type: 'moveVariable', origin: ContextVariable | Variable, destination: ContextVariable | Variable }
   | { type: 'changeVariableId', variables: (ContextVariable | Variable)[] }

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/reducer.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/reducer.ts
@@ -36,14 +36,14 @@ const updateItem = (state: SavingState, attribute: string, value: any, language?
   }
 
   if (language) {
-    const cleanedValue = cleanString(value);
+    const cleanedValue = value ? cleanString(value) : undefined;
     if (state.item[attribute] === undefined) {
       state.item[attribute] = { [language]: cleanedValue };
     } else {
       state.item[attribute][language] = cleanedValue;
     }
   } else {
-    if (value === '') {
+    if (value === '' || value === undefined) {
       delete state.item[attribute];
     } else {
       state.item[attribute] = value;
@@ -166,7 +166,7 @@ const setValidationMessage = (state: SavingState, index: number, language: strin
   }
 }
 
-const setValidationExpression = (state: SavingState, index: number, expression: string): void => {
+const setValidationExpression = (state: SavingState, index: number, expression: string | undefined): void => {
   if (!state.item) {
     return;
   }
@@ -281,11 +281,11 @@ const updateValueSetEntry = (state: SavingState, valueSetId: string, index: numb
   }
 }
 
-const updateValueSetEntryLabel = (state: SavingState, valueSetId: string, index: number, text: string | null, language: string): void => {
+const updateValueSetEntryLabel = (state: SavingState, valueSetId: string, index: number, text: string | null | undefined, language: string): void => {
   if (state.valueSets) {
     const vsIdx = state.valueSets.findIndex(vs => vs.id === valueSetId);
     if (vsIdx > -1 && text !== null && state.valueSets[vsIdx].entries !== undefined && state.valueSets[vsIdx].entries![index] !== undefined && state.valueSets[vsIdx].entries![index].label !== undefined) {
-      const cleanedText = cleanString(text);
+      const cleanedText = text ? cleanString(text) : undefined;
       state.valueSets[vsIdx].entries![index].label[language] = cleanedText;
     }
   }
@@ -401,7 +401,7 @@ const updateContextVariable = (state: SavingState, variableId: string, contextTy
   }
 }
 
-const updateExpressionVariable = (state: SavingState, variableId: string, expression: string): void => {
+const updateExpressionVariable = (state: SavingState, variableId: string, expression: string | undefined): void => {
   if (state.variables) {
     const varIdx = state.variables.findIndex(v => !isContextVariable(v) && v.name === variableId);
     if (varIdx > -1) {
@@ -428,7 +428,7 @@ const updateVariablePublishing = (state: SavingState, variableId: string, publis
   }
 }
 
-const updateVariableDescription = (state: SavingState, variableId: string, description: string): void => {
+const updateVariableDescription = (state: SavingState, variableId: string, description: string | undefined): void => {
   if (state.variables) {
     const varIdx = state.variables.findIndex(v => v.name === variableId);
     if (varIdx > -1) {

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/useSave.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/useSave.ts
@@ -6,7 +6,8 @@ import { TranslationResult } from '../../../backend/types';
 export const useSave = () => {
   const { state, dispatch } = useContext(SavingContext);
 
-  const updateItem = (itemId: string, attribute: string, value: string, language?: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const updateItem = (itemId: string, attribute: string, value: any, language?: string) => {
     dispatch({ type: 'updateItem', itemId, attribute, value, language });
   };
 
@@ -39,7 +40,7 @@ export const useSave = () => {
     dispatch({ type: 'setValidationMessage', itemId, index, language, message });
   }
 
-  const setValidationExpression = (itemId: string, index: number, expression: string) => {
+  const setValidationExpression = (itemId: string, index: number, expression: string | undefined) => {
     dispatch({ type: 'setValidationExpression', itemId, index, expression });
   }
 
@@ -63,7 +64,7 @@ export const useSave = () => {
     dispatch({ type: 'updateValueSetEntry', valueSetId, index, entry });
   }
 
-  const updateValueSetEntryLabel = (valueSetId: string, index: number, text: string | null, language: string) => {
+  const updateValueSetEntryLabel = (valueSetId: string, index: number, text: string | null | undefined, language: string) => {
     dispatch({ type: 'updateValueSetEntryLabel', valueSetId, index, text, language });
   }
 
@@ -96,7 +97,7 @@ export const useSave = () => {
     dispatch({ type: 'updateContextVariable', variableId, contextType, defaultValue });
   }
 
-  const updateExpressionVariable = (variableId: string, expression: string) => {
+  const updateExpressionVariable = (variableId: string, expression: string | undefined) => {
     dispatch({ type: 'updateExpressionVariable', variableId, expression });
   }
 
@@ -104,7 +105,7 @@ export const useSave = () => {
     dispatch({ type: 'updateVariablePublishing', variableId, published });
   }
 
-  const updateVariableDescription = (variableId: string, description: string) => {
+  const updateVariableDescription = (variableId: string, description: string | undefined) => {
     dispatch({ type: 'updateVariableDescription', variableId, description });
   }
 

--- a/frontend/dialob-composer-material/src/intl/en.ts
+++ b/frontend/dialob-composer-material/src/intl/en.ts
@@ -52,6 +52,7 @@ const en = {
   'buttons.add': 'Add',
   'buttons.translate': 'Translate',
   'buttons.translate.tooltip': 'Translate from {source} to {target} using AI',
+  'buttons.clear': 'Clear',
 
   'menus.options': 'Options',
   'menus.description': 'Description',

--- a/frontend/dialob-composer-material/src/types/index.ts
+++ b/frontend/dialob-composer-material/src/types/index.ts
@@ -1,11 +1,11 @@
 export type LocalizedString = {
-  [language: string]: string;
+  [language: string]: string | undefined;
 };
 
 export type Variable = {
   name: string;
   published?: boolean;
-  expression: string;
+  expression: string | undefined;
   description?: string;
 };
 

--- a/frontend/dialob-composer-material/src/utils/SearchUtils.ts
+++ b/frontend/dialob-composer-material/src/utils/SearchUtils.ts
@@ -74,13 +74,13 @@ export const matchVariableByKeyword = (variable: ContextVariable | Variable, key
     const snippet = extractSnippet(variable.name.toLowerCase(), keyword.toLowerCase());
     return { id: variable.name, type: 'variable', matchType: 'name', content: snippet };
   } else if (variable.description?.toLowerCase().includes(keyword.toLowerCase())) {
-    const snippet = extractSnippet(variable.description.toLowerCase(), keyword.toLowerCase());
+    const snippet = extractSnippet(variable.description?.toLowerCase() ?? '', keyword.toLowerCase());
     return { id: variable.name, type: 'variable', matchType: 'description', content: snippet };
   } else if ((variable as ContextVariable).defaultValue?.toLowerCase().includes(keyword.toLowerCase())) {
-    const snippet = extractSnippet((variable as ContextVariable).defaultValue.toLowerCase(), keyword.toLowerCase());
+    const snippet = extractSnippet((variable as ContextVariable).defaultValue?.toLowerCase() ?? '', keyword.toLowerCase());
     return { id: variable.name, type: 'variable', matchType: 'default', content: snippet };
   } else if ((variable as Variable).expression?.toLowerCase().includes(keyword.toLowerCase())) {
-    const snippet = extractSnippet((variable as Variable).expression.toLowerCase(), keyword.toLowerCase());
+    const snippet = extractSnippet((variable as Variable).expression?.toLowerCase() ?? '', keyword.toLowerCase());
     return { id: variable.name, type: 'variable', matchType: 'expression', content: snippet };
   }
   return undefined;

--- a/frontend/dialob-composer-material/src/utils/StringUtils.tsx
+++ b/frontend/dialob-composer-material/src/utils/StringUtils.tsx
@@ -20,7 +20,9 @@ export const cleanString = (str: string): string => {
 export const cleanLocalizedString = (str: LocalizedString): LocalizedString => {
   const cleanedStr = { ...str };
   Object.keys(str).map((key) => {
-    cleanedStr[key] = cleanString(str[key]);
+    if (str[key] !== undefined) {
+      cleanedStr[key] = cleanString(str[key]);
+    }
   });
   return cleanedStr;
 }


### PR DESCRIPTION
- synced treating of `''` and `undefined` in composer
- deleting a value in a text or code field leaves the field to be an empty string, which is sometimes intentional and sometimes can cause issues
- therefore added a clear button to all clearable fields (except ids and variable names) which is active when value is defined and clicking it sets the value to `undefined` or in case of `LocalizedString` will remove the language key

<img width="909" height="450" alt="image" src="https://github.com/user-attachments/assets/66633dbd-3108-4fe5-9d37-52d84ec72157" />
