### PR TITLE
Cell editing redesign

### DIFF
--- a/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
@@ -185,7 +185,7 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
               </IconButton>
             </TableCell>
 
-            <TableCell width='15%' sx={{ p: 0.5 }}>
+            <TableCell width={isGlobal ? '20%' : '15%'} sx={{ p: 0.5 }}>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localId)}</Typography>
                 <IconButton size='small' sx={editBtnSx(expandedField === 'id', theme.palette.warning.main)} onClick={() => toggleField('id')}>
@@ -216,7 +216,7 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
               const aiMetadata = isAITranslated(lang) ? getAITranslationMetadata(lang) : null;
 
               return (
-                <TableCell key={lang} width={formLanguages ? `${(isGlobal ? 70 : 55) / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
+                <TableCell key={lang} width={formLanguages ? `${(isGlobal ? 65 : 55) / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localizedString?.[lang])}</Typography>
                     <IconButton size='small' sx={editBtnSx(expandedField === lang, theme.palette.action.active)} onClick={() => toggleField(lang)}>
@@ -267,6 +267,7 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
                     onClear={localizedString?.[expandedField] !== undefined ? () => handleClearLanguage(expandedField) : undefined}
                     variant='standard'
                     fullWidth
+                    multiline
                     InputProps={{ disableUnderline: true }}
                     autoFocus
                     sx={{ pt: 0.5 }}

--- a/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { Box, IconButton, Table, TableBody, TableCell, TableRow, TextField, Tooltip, Typography, alpha, useTheme } from '@mui/material';
-import { ArrowDownward, ArrowUpward, Close, Visibility } from "@mui/icons-material";
+import { Box, IconButton, Table, TableBody, TableCell, TableRow, TextField, Typography, alpha, useTheme } from '@mui/material';
+import { ArrowDownward, ArrowUpward, Close, Edit } from "@mui/icons-material";
 import { useComposer } from "../dialob";
 import ChoiceDeleteDialog from "../dialogs/ChoiceDeleteDialog";
-import { FormattedMessage } from "react-intl";
 import { useErrorColor } from "../utils/ErrorUtils";
 import { useEditor } from "../editor";
 import CodeMirror from "./code/CodeMirror";
+import { CodeEditorWithClear } from "./code/CodeEditorWithClear";
+import { TextEditorWithClear } from "./editors/TextEditorWithClear";
 import { LocalizedString, ValueSetEntry } from "../types";
 import { useSave } from "../dialogs/contexts/saving/useSave";
 import { useBackend } from "../backend/useBackend";
@@ -29,47 +30,11 @@ export interface ChoiceItemProps {
   onMove?: (entry: ValueSetEntry, direction: 'up' | 'down') => void
 }
 
-const OverflowTooltipTextField: React.FC<React.ComponentProps<typeof TextField>> = ({ value, ...props }) => {
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  const [isOverflowing, setIsOverflowing] = React.useState(false);
+type ExpandedField = 'id' | 'rule' | string | null;
 
-  React.useEffect(() => {
-    const checkOverflow = () => {
-      if (inputRef.current) {
-        const el = inputRef.current;
-        const overflow = el.scrollWidth > (el.clientWidth + 1);
-        setIsOverflowing(overflow);
-      }
-    };
-
-    checkOverflow();
-
-    const resizeObserver = new ResizeObserver(() => {
-      checkOverflow();
-    });
-
-    if (inputRef.current) {
-      resizeObserver.observe(inputRef.current);
-    }
-
-    return () => resizeObserver.disconnect();
-  }, [value]);
-
-  const textField = (
-    <TextField
-      {...props}
-      inputRef={inputRef}
-      value={value}
-    />
-  );
-
-  return isOverflowing ? (
-    <Tooltip title={value + ''} placement='top' arrow>
-      {textField}
-    </Tooltip>
-  ) : (
-    textField
-  );
+const truncate = (value: string | undefined, maxLen = 28) => {
+  if (!value) return '';
+  return value.length > maxLen ? value.substring(0, maxLen) + '…' : value;
 };
 
 const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
@@ -84,13 +49,12 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
   const error = editor.errors?.find(e => e.itemId === valueSetId && e.index == index);
   const errorColor = useErrorColor(error);
   const backgroundColor = errorColor || theme.palette.background.paper;
-  const [entryExpanded, setEntryExpanded] = React.useState(false);
+  const [expandedField, setExpandedField] = React.useState<ExpandedField>(null);
   const [open, setOpen] = React.useState(false);
   const [localId, setLocalId] = React.useState(entry.id);
-  const [localizedString, setLocalizedString] = React.useState(entry.label || {});
+  const [localizedString, setLocalizedString] = React.useState<LocalizedString>(entry.label || {});
   const [localRule, setLocalRule] = React.useState(entry.when ?? '');
   const [translatingLanguage, setTranslatingLanguage] = React.useState<string | null>(null);
-  const inputRef = React.useRef<HTMLInputElement>(null);
   const length = savingState.valueSets?.find(v => v.id === valueSetId)?.entries?.length || 0;
 
   const getEntryId = (): string => {
@@ -98,53 +62,6 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
   };
 
   const { isAITranslated, getMetadata: getAITranslationMetadata, removeFlag } = useAITranslation(getEntryId());
-
-  const handleUpdate = (value: string, language: string) => {
-    setLocalizedString(prev => ({ ...prev, [language]: value }));
-  }
-
-  const handleClearLanguage = (language: string) => {
-    const updated = { ...localizedString };
-    delete updated[language];
-    setLocalizedString(updated);
-    onTextEdit(entry, updated);
-    if (isAITranslated(language)) {
-      removeFlag(language);
-    }
-  };
-
-  const handleBlurText = (language: string) => {
-    const currentValue = localizedString[language] || '';
-    const originalValue = entry.label?.[language] || '';
-    if (currentValue !== originalValue) {
-      onTextEdit(entry, localizedString);
-      
-      // Remove AI translation flag if user manually edits
-      if (isAITranslated(language)) {
-        removeFlag(language);
-      }
-    }
-  }
-
-  const handleUpdateRule = (value: string) => {
-    setLocalRule(value);
-  }
-
-  const handleBlurRule = (value: string) => {
-    if (value !== entry.when) {
-      onRuleEdit(entry, value);
-    }
-  }
-
-  const handleChangeId = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setLocalId(e.target.value);
-  }
-
-  const handleBlurId = () => {
-    if (localId !== entry.id) {
-      onUpdateId(entry, localId);
-    }
-  }
 
   React.useEffect(() => {
     setLocalId(entry.id);
@@ -158,13 +75,47 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
     setLocalRule(entry.when ?? '');
   }, [entry.when]);
 
+  const toggleField = (field: ExpandedField) => {
+    setExpandedField(prev => prev === field ? null : field);
+  };
+
+  const handleUpdate = (value: string, language: string) => {
+    const updated = { ...localizedString, [language]: value };
+    setLocalizedString(updated);
+    onTextEdit(entry, updated);
+    if (isAITranslated(language)) {
+      removeFlag(language);
+    }
+  };
+
+  const handleClearLanguage = (language: string) => {
+    const updated = { ...localizedString };
+    delete updated[language];
+    setLocalizedString(updated);
+    onTextEdit(entry, updated);
+    if (isAITranslated(language)) {
+      removeFlag(language);
+    }
+  };
+
+  const handleChangeId = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newId = e.target.value;
+    setLocalId(newId);
+    onUpdateId(entry, newId);
+  };
+
+  const handleUpdateRule = (value: string) => {
+    setLocalRule(value);
+    onRuleEdit(entry, value);
+  };
+
   const handleMove = (direction: 'up' | 'down') => {
     if (valueSetId) {
       const newIndex = direction === 'up' ? index - 1 : index + 1;
       moveValueSetEntry(valueSetId, index, newIndex);
       onMove?.(entry, direction);
     }
-  }
+  };
 
   const handleTranslate = async (targetLanguage: string) => {
     const sourceLanguage = editor.activeFormLanguage;
@@ -193,7 +144,6 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
         const translationResponse = response.result as TranslationResponse;
         if (translationResponse.translations && translationResponse.translations.length > 0) {
           applyTranslations(translationResponse.translations, sourceLanguage, targetLanguage);
-          
           const translation = translationResponse.translations[0];
           setLocalizedString(prev => ({ ...prev, [targetLanguage]: translation.translatedText }));
         }
@@ -207,6 +157,17 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
     }
   };
 
+  const editBtnSx = (active: boolean, color: string) => ({
+    p: 0.5, ml: 0.5,
+    ...(active && { border: `1px solid ${color}` }),
+  });
+
+  const expandedBg =
+    expandedField === 'id' ? alpha(theme.palette.warning.main, 0.06) :
+    expandedField === 'rule' ? alpha(theme.palette.primary.main, 0.06) :
+    undefined;
+
+  const colSpan = isGlobal ? 2 + languageNo : 3 + languageNo;
 
   return (
     <>
@@ -216,7 +177,6 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
           <TableRow sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
             <TableCell align='center' width='15%'>
               <IconButton sx={{ p: 0.5 }} onClick={() => setOpen(true)}><Close color='error' /></IconButton>
-              {!isGlobal && <IconButton onClick={() => setEntryExpanded(!entryExpanded)}><Visibility color={entry.when ? 'primary' : 'inherit'} /></IconButton>}
               <IconButton sx={{ p: 0.5 }} onClick={() => handleMove('up')} disabled={index === 0}>
                 <ArrowUpward />
               </IconButton>
@@ -224,13 +184,29 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
                 <ArrowDownward />
               </IconButton>
             </TableCell>
-            <TableCell width='20%' sx={{ p: 0.5 }}>
-              <TextField value={localId} onChange={handleChangeId} onBlur={handleBlurId}
-                variant='standard' fullWidth inputRef={inputRef}
-                InputProps={{
-                  disableUnderline: true
-                }} />
+
+            <TableCell width='15%' sx={{ p: 0.5 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localId)}</Typography>
+                <IconButton size='small' sx={editBtnSx(expandedField === 'id', theme.palette.warning.main)} onClick={() => toggleField('id')}>
+                  <Edit fontSize='small' color={expandedField === 'id' ? 'warning' : 'inherit'} />
+                </IconButton>
+              </Box>
             </TableCell>
+
+            {!isGlobal && (
+              <TableCell width='15%' sx={{ p: 0.5 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <Typography variant='body2' noWrap sx={{ flex: 1, color: entry.when ? 'text.primary' : 'text.disabled' }}>
+                    {truncate(entry.when)}
+                  </Typography>
+                  <IconButton size='small' sx={editBtnSx(expandedField === 'rule', theme.palette.primary.main)} onClick={() => toggleField('rule')}>
+                    <Edit fontSize='small' color={expandedField === 'rule' ? 'primary' : 'inherit'} />
+                  </IconButton>
+                </Box>
+              </TableCell>
+            )}
+
             {formLanguages?.map(lang => {
               const hasValue = localizedString && localizedString[lang] !== undefined;
               const sourceLanguage = editor.activeFormLanguage;
@@ -240,30 +216,12 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
               const aiMetadata = isAITranslated(lang) ? getAITranslationMetadata(lang) : null;
 
               return (
-                <TableCell key={lang} width={formLanguages ? `${65 / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
+                <TableCell key={lang} width={formLanguages ? `${(isGlobal ? 70 : 55) / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    <OverflowTooltipTextField 
-                      value={localizedString ? localizedString[lang] : ''} 
-                      variant="standard" 
-                      fullWidth 
-                      InputProps={{ disableUnderline: true }} 
-                      onChange={(e) => handleUpdate(e.target.value, lang)}
-                      onBlur={() => handleBlurText(lang)}
-                    />
-                    {hasValue && (
-                      <Tooltip title={<FormattedMessage id="buttons.clear" />}>
-                        <span>
-                          <IconButton
-                            disabled={!hasValue}
-                            onClick={() => handleClearLanguage(lang)}
-                            size="small"
-                            sx={{ p: 0.25 }}
-                          >
-                            <Close fontSize="small" />
-                          </IconButton>
-                        </span>
-                      </Tooltip>
-                    )}
+                    <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localizedString?.[lang])}</Typography>
+                    <IconButton size='small' sx={editBtnSx(expandedField === lang, theme.palette.action.active)} onClick={() => toggleField(lang)}>
+                      <Edit fontSize='small' color='inherit' />
+                    </IconButton>
                     {canTranslate && (
                       <TranslateButton
                         sourceLanguage={sourceLanguage}
@@ -273,8 +231,8 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
                       />
                     )}
                     {aiMetadata && (
-                      <AITranslationIndicator 
-                        metadata={aiMetadata} 
+                      <AITranslationIndicator
+                        metadata={aiMetadata}
                         onClick={() => removeFlag(lang)}
                       />
                     )}
@@ -283,18 +241,44 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
               );
             })}
           </TableRow>
-          {entryExpanded && !isGlobal && <TableRow>
-            <TableCell colSpan={2 + languageNo}>
-              {!isGlobal && <Box sx={{ display: 'flex', flexDirection: 'column', p: 1 }}>
-                <Typography color='text.hint' variant='caption'><FormattedMessage id='dialogs.options.rules.visibility' /></Typography>
-                <CodeMirror value={localRule} onChange={handleUpdateRule} onBlur={() => handleBlurRule(localRule)} />
-              </Box>}
-            </TableCell>
-          </TableRow>}
+
+          {expandedField && (
+            <TableRow>
+              <TableCell colSpan={colSpan} sx={{ p: 1, backgroundColor: expandedBg }}>
+                {expandedField === 'id' && (
+                  <TextField
+                    value={localId}
+                    onChange={handleChangeId}
+                    variant='standard'
+                    fullWidth
+                    InputProps={{ disableUnderline: true }}
+                    autoFocus
+                  />
+                )}
+                {expandedField === 'rule' && (
+                  <CodeEditorWithClear value={localRule || undefined} onClear={() => handleUpdateRule('')}>
+                    <CodeMirror value={localRule} onChange={handleUpdateRule} />
+                  </CodeEditorWithClear>
+                )}
+                {formLanguages?.includes(expandedField) && (
+                  <TextEditorWithClear
+                    value={localizedString?.[expandedField]}
+                    onChange={(value) => handleUpdate(value, expandedField)}
+                    onClear={localizedString?.[expandedField] !== undefined ? () => handleClearLanguage(expandedField) : undefined}
+                    variant='standard'
+                    fullWidth
+                    InputProps={{ disableUnderline: true }}
+                    autoFocus
+                    sx={{ pt: 0.5 }}
+                  />
+                )}
+              </TableCell>
+            </TableRow>
+          )}
         </TableBody>
-      </Table >
+      </Table>
     </>
   );
-}
+};
 
 export default ChoiceItem;

--- a/frontend/dialob-composer-material/src/components/ChoiceList.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceList.tsx
@@ -70,10 +70,10 @@ const ChoiceList: React.FC<{
   return (
     <TableBody>
       <TableRow>
-        <TableCell colSpan={2 + languageNo}>
+        <TableCell colSpan={isGlobal ? 2 + languageNo : 3 + languageNo}>
           {valueSet?.entries && valueSet.entries?.length > 0 && valueSet.entries.map((entry, index) => (
             <ChoiceItem 
-              key={`${valueSet.id}-${entry.id}`}
+              key={`${valueSet.id}-${index}`}
               entry={entry}
               index={index}
               valueSetId={valueSet.id}

--- a/frontend/dialob-composer-material/src/components/editors/ChoiceEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/ChoiceEditor.tsx
@@ -197,11 +197,14 @@ const ChoiceEditor: React.FC = () => {
                     </IconButton>
                   )}
                 </TableCell>
-                <TableCell width='20%' sx={{ p: 1 }}>
+                <TableCell width='15%' sx={{ p: 1 }}>
                   <Typography fontWeight='bold'><FormattedMessage id='dialogs.options.key' /></Typography>
                 </TableCell>
+                <TableCell width='15%' sx={{ p: 1 }}>
+                  <Typography fontWeight='bold'><FormattedMessage id='dialogs.options.rules.visibility' /></Typography>
+                </TableCell>
                 {formLanguages?.map(lang => (
-                  <TableCell key={lang} width={formLanguages ? `${65 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
+                  <TableCell key={lang} width={formLanguages ? `${55 / formLanguages.length}%` : 0} sx={{ p: 1 }}>
                     <Typography fontWeight='bold'>
                       <FormattedMessage id='dialogs.options.text' values={{ language: lang }} />
                     </Typography>

--- a/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, IconButton, TableCell, TableRow, alpha, useTheme } from '@mui/material';
+import { Box, IconButton, TableCell, TableRow, Typography, alpha, useTheme } from '@mui/material';
 import { ContextVariable } from '../../types';
 import { useEditor } from '../../editor';
 import { useErrorColorSx } from '../../utils/ErrorUtils';
@@ -7,12 +7,13 @@ import {
   ContextTypeMenu, DefaultValueField, DeleteButton, DescriptionField,
   NameField, PublishedSwitch, UsersField, VariableProps
 } from './VariableComponents';
-import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
+import { ArrowDownward, ArrowUpward, Edit } from '@mui/icons-material';
 import { isContextVariable } from '../../utils/ItemUtils';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
 
+type ExpandedField = 'name' | 'defaultValue' | 'description' | null;
 
-const ContextVariableRow: React.FC<VariableProps> = ({ index, item, onClose }) => {
+const ContextVariableRow: React.FC<VariableProps> = React.memo(function ContextVariableRow({ index, item, onClose }) {
   const { editor } = useEditor();
   const { savingState, moveVariable } = useSave();
   const theme = useTheme();
@@ -20,7 +21,8 @@ const ContextVariableRow: React.FC<VariableProps> = ({ index, item, onClose }) =
   const errorColorSx = useErrorColorSx(editor.errors, variable.name);
   const backgroundColor = errorColorSx ? errorColorSx : theme.palette.background.paper;
   const contextVariables = savingState.variables?.filter(v => isContextVariable(v));
- 
+  const [expandedField, setExpandedField] = React.useState<ExpandedField>(null);
+
   const handleMove = (direction: 'up' | 'down') => {
     const destination = direction === 'up' ? index - 1 : index + 1;
     const destinationVariable = contextVariables?.[destination];
@@ -29,45 +31,89 @@ const ContextVariableRow: React.FC<VariableProps> = ({ index, item, onClose }) =
     }
   }
 
+  const toggleField = (field: ExpandedField) => {
+    setExpandedField(prev => prev === field ? null : field);
+  };
+
+  const truncate = (value: string | undefined, maxLen = 24) => {
+    if (!value) return '';
+    return value.length > maxLen ? value.substring(0, maxLen) + '…' : value;
+  };
+
+  const expandedBg = expandedField === 'name'
+    ? alpha(theme.palette.warning.main, 0.06)
+    : undefined;
+
+  const editBtnSx = (active: boolean, color: string) => ({
+    p: 0.5, ml: 0.5,
+    ...(active && { border: `1px solid ${color}` }),
+  });
+
   return (
-    <TableRow key={variable.name} sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
-      <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <DeleteButton variable={variable} />
-          <IconButton
-            sx={{ p: 0.5 }}
-            disabled={index === 0}
-            onClick={() => handleMove('up')}>
-              <ArrowUpward />
+    <>
+      <TableRow key={variable.name} sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
+        <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <DeleteButton variable={variable} />
+            <IconButton
+              sx={{ p: 0.5 }}
+              disabled={index === 0}
+              onClick={() => handleMove('up')}>
+                <ArrowUpward />
+              </IconButton>
+            <IconButton
+              sx={{ p: 0.5 }}
+              disabled={index === (contextVariables?.length || 0) - 1}
+              onClick={() => handleMove('down')}>
+              <ArrowDownward />
             </IconButton>
-          <IconButton
-            sx={{ p: 0.5 }}
-            disabled={index === (contextVariables?.length || 0) - 1}
-            onClick={() => handleMove('down')}>
-              <ArrowDownward /> 
-          </IconButton>
-        </Box>
-      </TableCell>
-      <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
-        <PublishedSwitch variable={variable} />
-      </TableCell>
-      <TableCell width='25%' sx={{ p: 0.5 }}>
-        <NameField variable={variable} />
-      </TableCell>
-      <TableCell width='10%' sx={{ p: 0.5 }}>
-        <ContextTypeMenu variable={variable} />
-      </TableCell>
-      <TableCell width='15%' sx={{ p: 0.5 }}>
-        <DefaultValueField variable={variable} />
-      </TableCell>
-      <TableCell width='20%' sx={{ p: 0.5 }}>
-        <DescriptionField variable={variable} />
-      </TableCell>
-      <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
-        <UsersField variable={variable} onClose={onClose} />
-      </TableCell>
-    </TableRow>
+          </Box>
+        </TableCell>
+        <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
+          <PublishedSwitch variable={variable} />
+        </TableCell>
+        <TableCell width='25%' sx={{ p: 0.5 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant='body2' noWrap sx={{ flex: 1 }}>{variable.name}</Typography>
+            <IconButton size='small' sx={editBtnSx(expandedField === 'name', theme.palette.warning.main)} onClick={() => toggleField('name')}>
+              <Edit fontSize='small' color={expandedField === 'name' ? 'warning' : 'inherit'} />
+            </IconButton>
+          </Box>
+        </TableCell>
+        <TableCell width='10%' sx={{ p: 0.5 }}>
+          <ContextTypeMenu variable={variable} />
+        </TableCell>
+        <TableCell width='15%' sx={{ p: 0.5 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(variable.defaultValue)}</Typography>
+            <IconButton size='small' sx={editBtnSx(expandedField === 'defaultValue', theme.palette.primary.main)} onClick={() => toggleField('defaultValue')}>
+              <Edit fontSize='small' color='inherit' />
+            </IconButton>
+          </Box>
+        </TableCell>
+        <TableCell width='20%' sx={{ p: 0.5 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(variable.description)}</Typography>
+            <IconButton size='small' sx={editBtnSx(expandedField === 'description', theme.palette.primary.main)} onClick={() => toggleField('description')}>
+              <Edit fontSize='small' color='inherit' />
+            </IconButton>
+          </Box>
+        </TableCell>
+        <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
+          <UsersField variable={variable} onClose={onClose} />
+        </TableCell>
+      </TableRow>
+      {expandedField && (
+        <TableRow>
+          <TableCell colSpan={7} sx={{ p: 1, backgroundColor: expandedBg }}>
+            {expandedField === 'name' && <NameField variable={variable} />}
+            {expandedField === 'defaultValue' && <DefaultValueField variable={variable} />}
+            {expandedField === 'description' && <DescriptionField variable={variable} />}
+          </TableCell>
+        </TableRow>
+      )}
+    </>
   );
-}
+});
 
 export default ContextVariableRow;

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
@@ -9,7 +9,9 @@ import { ErrorMessage } from '../ErrorComponents';
 import { isContextVariable } from '../../utils/ItemUtils';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
 
-const ExpressionVariableRow: React.FC<VariableProps> = ({ index, item, onClose }) => {
+type ExpandedField = 'name' | 'expression' | 'description' | null;
+
+const ExpressionVariableRow: React.FC<VariableProps> = React.memo(function ExpressionVariableRow({ index, item, onClose }) {
   const { editor } = useEditor();
   const { savingState, moveVariable } = useSave();
   const theme = useTheme();
@@ -17,7 +19,7 @@ const ExpressionVariableRow: React.FC<VariableProps> = ({ index, item, onClose }
   const errorColorSx = useErrorColorSx(editor.errors, variable.name);
   const backgroundColor = errorColorSx ? errorColorSx : theme.palette.background.paper;
   const itemErrors = editor.errors?.filter(e => e.itemId === variable.name);
-  const [expanded, setExpanded] = React.useState<boolean>(false);
+  const [expandedField, setExpandedField] = React.useState<ExpandedField>(null);
   const expressionVariables = savingState.variables?.filter(v => !isContextVariable(v));
 
   const handleMove = (direction: 'up' | 'down') => {
@@ -27,6 +29,26 @@ const ExpressionVariableRow: React.FC<VariableProps> = ({ index, item, onClose }
       moveVariable(variable, destinationVariable);
     }
   }
+
+  const toggleField = (field: ExpandedField) => {
+    setExpandedField(prev => prev === field ? null : field);
+  };
+
+  const truncate = (value: string | undefined, maxLen = 24) => {
+    if (!value) return '';
+    return value.length > maxLen ? value.substring(0, maxLen) + '…' : value;
+  };
+
+  const expandedBg = expandedField === 'name'
+    ? alpha(theme.palette.warning.main, 0.06)
+    : expandedField === 'expression'
+      ? alpha(theme.palette.primary.main, 0.06)
+      : undefined;
+
+  const editBtnSx = (active: boolean, color: string) => ({
+    p: 0.5, ml: 0.5,
+    ...(active && { border: `1px solid ${color}` }),
+  });
 
   return (
     <>
@@ -44,7 +66,7 @@ const ExpressionVariableRow: React.FC<VariableProps> = ({ index, item, onClose }
               sx={{ p: 0.5 }}
               disabled={index === (expressionVariables?.length || 0) - 1}
               onClick={() => handleMove('down')}>
-                <ArrowDownward /> 
+              <ArrowDownward />
             </IconButton>
           </Box>
         </TableCell>
@@ -52,37 +74,55 @@ const ExpressionVariableRow: React.FC<VariableProps> = ({ index, item, onClose }
           <PublishedSwitch variable={variable} />
         </TableCell>
         <TableCell width='20%' sx={{ p: 1 }}>
-          <NameField variable={variable} />
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant='body2' noWrap sx={{ flex: 1 }}>{variable.name}</Typography>
+            <IconButton size='small' sx={editBtnSx(expandedField === 'name', theme.palette.warning.main)} onClick={() => toggleField('name')}>
+              <Edit fontSize='small' color={expandedField === 'name' ? 'warning' : 'inherit'} />
+            </IconButton>
+          </Box>
         </TableCell>
         <TableCell width='25%' sx={{ p: 1 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            {variable.expression && (variable.expression.substring(0, 20) + (variable.expression.length > 20 ? '...' : ''))}
-            <IconButton onClick={() => setExpanded(!expanded)}><Edit color={expanded ? 'primary' : 'inherit'} /></IconButton>
+            <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(variable.expression)}</Typography>
+            <IconButton size='small' sx={editBtnSx(expandedField === 'expression', theme.palette.primary.main)} onClick={() => toggleField('expression')}>
+              <Edit fontSize='small' color={expandedField === 'expression' ? 'primary' : 'inherit'} />
+            </IconButton>
           </Box>
         </TableCell>
         <TableCell width='20%' sx={{ p: 1 }}>
-          <DescriptionField variable={variable} />
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(variable.description)}</Typography>
+            <IconButton size='small' sx={editBtnSx(expandedField === 'description', theme.palette.primary.main)} onClick={() => toggleField('description')}>
+              <Edit fontSize='small' color='inherit' />
+            </IconButton>
+          </Box>
         </TableCell>
         <TableCell width='10%' align='center' sx={{ p: 1 }}>
           <UsersField variable={variable} onClose={onClose} />
         </TableCell>
       </TableRow>
-      {expanded && <>
+      {expandedField && (
         <TableRow>
-          <TableCell colSpan={6}>
-            <ExpressionField variable={variable} errors={itemErrors} />
+          <TableCell colSpan={6} sx={{ p: 1, backgroundColor: expandedBg }}>
+            {expandedField === 'name' && <NameField variable={variable} />}
+            {expandedField === 'expression' && <ExpressionField variable={variable} errors={itemErrors} />}
+            {expandedField === 'description' && <DescriptionField variable={variable} />}
           </TableCell>
         </TableRow>
+      )}
+      {expandedField === 'expression' && itemErrors && itemErrors.length > 0 && (
         <TableRow>
           <TableCell colSpan={6}>
-            {itemErrors?.map((error, index) => <Alert key={index} severity={getErrorSeverity(error)} sx={{ mt: 2 }} icon={<Warning />}>
-              <Typography color={error.level.toLowerCase()}><ErrorMessage error={error} /></Typography>
-            </Alert>)}
+            {itemErrors.map((error, i) => (
+              <Alert key={i} severity={getErrorSeverity(error)} sx={{ mt: 1 }} icon={<Warning />}>
+                <Typography color={error.level.toLowerCase()}><ErrorMessage error={error} /></Typography>
+              </Alert>
+            ))}
           </TableCell>
         </TableRow>
-      </>}
+      )}
     </>
   );
-}
+});
 
 export default ExpressionVariableRow;

--- a/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Button, IconButton, List, ListItemButton, Menu, MenuItem, Popover, Switch, TextField, Tooltip, Typography } from '@mui/material';
 import { MAX_VARIABLE_DESCRIPTION_LENGTH } from '../../defaults';
-import { Check, Close, Delete, KeyboardArrowDown } from '@mui/icons-material';
+import { Delete, KeyboardArrowDown } from '@mui/icons-material';
 import { EditorError, useEditor } from '../../editor';
 import { scrollToItem } from '../../utils/ScrollUtils';
 import { FormattedMessage } from 'react-intl';
@@ -9,8 +9,6 @@ import { matchItemByKeyword } from '../../utils/SearchUtils';
 import CodeMirror from '../code/CodeMirror';
 import { validateId } from '../../utils/ValidateUtils';
 import { CodeEditorWithClear } from '../code/CodeEditorWithClear';
-import { useBackend } from '../../backend/useBackend';
-import { ChangeIdResult } from '../../backend/types';
 import { ContextVariable, ContextVariableType, DialobItem, Variable } from '../../types';
 import { useComposer } from '../../dialob';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
@@ -46,71 +44,53 @@ export const PublishedSwitch: React.FC<{ variable: ContextVariable | Variable }>
 }
 
 export const NameField: React.FC<{ variable: ContextVariable | Variable }> = ({ variable }) => {
-  const { changeItemId } = useBackend();
-  const { form, setForm, setRevision } = useComposer();
-  const { setErrors } = useEditor();
-  const { changeVariableId, savingState } = useSave();
-  const [editMode, setEditMode] = React.useState(false);
+  const { form } = useComposer();
+  const { updateVariableName, savingState } = useSave();
+  const originalNameRef = React.useRef(variable.name);
+  const [name, setName] = React.useState<string>(variable.name);
   const [idError, setIdError] = React.useState(false);
 
-  // disable changing name if there are unsaved changes
-  const hasChanges = React.useMemo(() => {
-      return savingState.variables && (JSON.stringify(savingState.variables) !== JSON.stringify(form.variables));
-  }, [savingState, form.variables]);
+  // After a save the pending renames are cleared. At that point variable.name is the
+  // newly-committed name, so originalNameRef must be updated to it. Without this,
+  // a second rename in the same session would dispatch with a stale "from" value that
+  // no longer exists in the form, causing the backend rename to fail.
+  React.useEffect(() => {
+    const hasPendingRename = savingState.pendingVariableRenames?.some(r => r.to === variable.name);
+    if (!hasPendingRename && originalNameRef.current !== variable.name) {
+      originalNameRef.current = variable.name;
+      setName(variable.name);
+      setIdError(false);
+    }
+  }, [savingState.pendingVariableRenames, variable.name]);
 
-  const handleChangeName = () => {
-    if (name !== variable.name) {
-      if (validateId(name, form.data, form.variables)) {
-        changeItemId(form, variable.name, name).then((response) => {
-          const result = response.result as ChangeIdResult;
-          if (response.success) {
-            setForm(result.form);
-            setErrors(result.errors);
-            setIdError(false);
-            setRevision(result.rev);
-            if (result.form.variables) {
-              // this is necessary to keep the saving state in sync, but will discard unsaved changes
-              changeVariableId(result.form.variables);
-            }
-          } else if (response.apiError) {
-            setErrors([{ level: 'FATAL', message: response.apiError.message }]);
-          }
-          setEditMode(false);
-        });
-      } else {
-        setIdError(true);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newName = e.target.value;
+    setName(newName);
+
+    const otherSavingVars = savingState.variables?.filter(v => v.name !== variable.name);
+    const isValid = newName === originalNameRef.current || validateId(newName, form.data, otherSavingVars);
+
+    if (isValid) {
+      setIdError(false);
+      if (newName !== variable.name) {
+        updateVariableName(variable.name, originalNameRef.current, newName);
       }
+    } else {
+      setIdError(true);
     }
-  }
+  };
 
-  const handleDiscardChange = () => {
-    setEditMode(false);
-    setIdError(false);
-    setName(variable.name);
-  }
-
-  const handleCloseChange = () => {
-    if (name === variable.name) {
-      setEditMode(false);
-    }
-  }
-
-  const [name, setName] = React.useState<string>(variable.name);
   return (
-    <TextField value={name} onChange={(e) => setName(e.target.value)} variant='standard' fullWidth error={idError}
-      onFocus={() => setEditMode(true)} onBlur={handleCloseChange} helperText={editMode && <FormattedMessage id='dialogs.change.id.tip' />} InputProps={{
-        disableUnderline: true,
-        endAdornment: (
-          editMode && <>
-            <Tooltip title={<FormattedMessage id='dialogs.change.id.tooltip' />}>
-              <span>
-                <IconButton onClick={handleChangeName} disabled={hasChanges}><Check color={hasChanges ? 'disabled' : 'success'} /></IconButton>
-              </span>
-            </Tooltip>
-            <IconButton onClick={handleDiscardChange}><Close color='error' /></IconButton>
-          </>
-        )
-      }} />
+    <TextField
+      value={name}
+      onChange={handleChange}
+      variant='standard'
+      fullWidth
+      error={idError}
+      helperText={idError ? <FormattedMessage id='dialogs.change.id.tip' /> : undefined}
+      InputProps={{ disableUnderline: true }}
+      autoFocus
+    />
   );
 }
 
@@ -118,11 +98,14 @@ export const DescriptionField: React.FC<{ variable: Variable | ContextVariable }
   const { updateVariableDescription } = useSave();
   const [description, setDescription] = React.useState<string | undefined>(variable.description);
 
-  const handleBlur = () => {
-    if (description !== variable.description) {
-      updateVariableDescription(variable.name, description);
-    }
-  }
+  React.useEffect(() => {
+    setDescription(variable.description);
+  }, [variable.name, variable.description]);
+
+  const handleChange = (value: string) => {
+    setDescription(value);
+    updateVariableDescription(variable.name, value);
+  };
 
   const handleClear = () => {
     setDescription(undefined);
@@ -132,8 +115,7 @@ export const DescriptionField: React.FC<{ variable: Variable | ContextVariable }
   return (
     <TextEditorWithClear
       value={description}
-      onChange={(value) => setDescription(value)}
-      onBlur={handleBlur}
+      onChange={handleChange}
       variant='standard'
       InputProps={{ 
         disableUnderline: true,
@@ -141,6 +123,7 @@ export const DescriptionField: React.FC<{ variable: Variable | ContextVariable }
       onClear={handleClear}
       inputProps={{ maxLength: MAX_VARIABLE_DESCRIPTION_LENGTH }}
       fullWidth
+      autoFocus
     />
   );
 }
@@ -188,11 +171,14 @@ export const DefaultValueField: React.FC<{ variable: ContextVariable }> = ({ var
   const { updateContextVariable } = useSave();
   const [defaultValue, setDefaultValue] = React.useState<string | undefined>(variable.defaultValue);
 
-  const handleBlur = () => {
-    if (defaultValue !== variable.defaultValue) {
-      updateContextVariable(variable.name, undefined, defaultValue);
-    }
-  }
+  React.useEffect(() => {
+    setDefaultValue(variable.defaultValue);
+  }, [variable.name, variable.defaultValue]);
+
+  const handleChange = (value: string) => {
+    setDefaultValue(value);
+    updateContextVariable(variable.name, undefined, value);
+  };
 
   const handleClear = () => {
     setDefaultValue(undefined);
@@ -202,14 +188,14 @@ export const DefaultValueField: React.FC<{ variable: ContextVariable }> = ({ var
   return (
     <TextEditorWithClear
       value={defaultValue}
-      onChange={(value) => setDefaultValue(value)}
-      onBlur={handleBlur}
+      onChange={handleChange}
       variant='standard'
       InputProps={{ 
         disableUnderline: true, 
       }}
       onClear={handleClear}
       fullWidth
+      autoFocus
     />
   );
 }
@@ -218,11 +204,14 @@ export const ExpressionField: React.FC<{ variable: Variable, errors?: EditorErro
   const { updateExpressionVariable } = useSave();
   const [expression, setExpression] = React.useState<string | undefined>(variable.expression);
 
-  const handleBlur = () => {
-    if (expression !== variable.expression) {
-      updateExpressionVariable(variable.name, expression);
-    }
-  }
+  React.useEffect(() => {
+    setExpression(variable.expression);
+  }, [variable.name, variable.expression]);
+
+  const handleChange = (value: string) => {
+    setExpression(value);
+    updateExpressionVariable(variable.name, value);
+  };
 
   const handleClear = () => {
     setExpression(undefined);
@@ -232,7 +221,7 @@ export const ExpressionField: React.FC<{ variable: Variable, errors?: EditorErro
   return (
     <Box sx={{ p: 1 }}>
       <CodeEditorWithClear value={expression} onClear={handleClear}>
-        <CodeMirror value={expression ?? ''} onChange={(e) => setExpression(e)} onBlur={handleBlur} errors={errors} />
+        <CodeMirror value={expression ?? ''} onChange={handleChange} errors={errors} />
       </CodeEditorWithClear>
     </Box>
   );

--- a/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
@@ -124,6 +124,7 @@ export const DescriptionField: React.FC<{ variable: Variable | ContextVariable }
       inputProps={{ maxLength: MAX_VARIABLE_DESCRIPTION_LENGTH }}
       fullWidth
       autoFocus
+      multiline
     />
   );
 }

--- a/frontend/dialob-composer-material/src/dialob/actions.ts
+++ b/frontend/dialob-composer-material/src/dialob/actions.ts
@@ -58,6 +58,7 @@ export type ComposerAction =
   | { type: 'applyItemChanges', newState: SavingState }
   | { type: 'applyListChanges', newState: SavingState }
   | { type: 'applyVariableChanges', newState: SavingState }
+  | { type: 'applyVariableList', variables: (ContextVariable | Variable)[] }
   | { type: 'applyFormChanges', newState: SavingState }
 
   | { type: 'applyTranslations', translations: TranslationResult[], sourceLanguage: string, targetLanguage: string }

--- a/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
+++ b/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
@@ -175,6 +175,10 @@ export const useComposer = () => {
     dispatch({ type: 'applyVariableChanges', newState });
   }
 
+  const applyVariableList = (variables: (ContextVariable | Variable)[]) => {
+    dispatch({ type: 'applyVariableList', variables });
+  }
+
   const applyFormChanges = (newState: SavingState) => {
     dispatch({ type: 'applyFormChanges', newState });
   }
@@ -228,6 +232,7 @@ export const useComposer = () => {
     applyItemChanges,
     applyListChanges,
     applyVariableChanges,
+    applyVariableList,
     applyFormChanges,
     applyTranslations,
     removeAITranslation,

--- a/frontend/dialob-composer-material/src/dialob/reducer.ts
+++ b/frontend/dialob-composer-material/src/dialob/reducer.ts
@@ -761,6 +761,10 @@ const applyVariableChanges = (state: ComposerState, newState: SavingState): void
   }
 }
 
+const applyVariableList = (state: ComposerState, variables: (ContextVariable | Variable)[]): void => {
+  state.variables = variables;
+}
+
 const applyFormChanges = (state: ComposerState, newState: SavingState): void => {
   // Apply changes from the SavingContext - used to apply changes made in the FormOptionsDialog
   if (!newState.formMetadata) {
@@ -934,6 +938,8 @@ export const formReducer = (state: ComposerState, action: ComposerAction, callba
       applyListChanges(state, action.newState);
     } else if (action.type === 'applyVariableChanges') {
       applyVariableChanges(state, action.newState);
+    } else if (action.type === 'applyVariableList') {
+      applyVariableList(state, action.variables);
     } else if (action.type === 'applyFormChanges') {
       applyFormChanges(state, action.newState);
     } else if (action.type === 'applyTranslations') {

--- a/frontend/dialob-composer-material/src/dialogs/VariablesDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/VariablesDialog.tsx
@@ -9,22 +9,86 @@ import { useDocs } from '../utils/DocsUtils';
 import { SavingProvider } from './contexts/saving/SavingProvider';
 import { useComposer } from '../dialob';
 import { useSave } from './contexts/saving/useSave';
-
+import { useBackend } from '../backend/useBackend';
+import { ChangeIdResult } from '../backend/types';
+import { ContextVariable, Variable } from '../types';
 
 const SaveButton: React.FC = () => {
-  const { form, applyVariableChanges } = useComposer();
-  const { savingState } = useSave();
+  const { form, applyVariableChanges, applyVariableList, setForm, setRevision } = useComposer();
+  const { setErrors } = useEditor();
+  const { savingState, clearPendingRenames, resetItems, resetVariables } = useSave();
+  const { changeItemId } = useBackend();
 
   const hasChanges = React.useMemo(() => {
       const variablesChanged = savingState.variables && (JSON.stringify(savingState.variables) !== JSON.stringify(form.variables));
       const itemsChanged = savingState.items && (JSON.stringify(savingState.items) !== JSON.stringify(form.data));
-      return variablesChanged || itemsChanged;
+      const hasRenames = savingState.pendingVariableRenames && savingState.pendingVariableRenames.length > 0;
+      return variablesChanged || itemsChanged || hasRenames;
   }, [savingState, form.variables, form.data]);
 
-  const handleSave = () => {
-    if (savingState.variables) {
+  const handleSave = async () => {
+    if (!savingState.variables) return;
+
+    const renames = savingState.pendingVariableRenames ?? [];
+    let currentForm = form;
+    let latestRev: string | undefined;
+
+    for (const rename of renames) {
+      const response = await changeItemId(currentForm, rename.from, rename.to);
+      if (response.success) {
+        const result = response.result as ChangeIdResult;
+        currentForm = result.form;
+        latestRev = result.rev;
+        setErrors(result.errors);
+      } else if (response.apiError) {
+        setErrors([{ level: 'FATAL', message: response.apiError.message }]);
+        return;
+      }
+    }
+
+    if (renames.length > 0) {
+      const applyRenamesToExpression = (expression: string): string =>
+        renames.reduce((expr, { from, to }) =>
+          expr.replace(new RegExp(`\\b${from.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'g'), to),
+          expression
+        );
+
+      // Build merged variables: user-staged properties take precedence, but for expressions
+      // we must reconcile user edits with backend-applied renames:
+      // - if the user edited the expression, apply rename substitutions to their staged version
+      // - if the user left it untouched, use the API result (rename already applied by the backend)
+      const mergedVariables: (ContextVariable | Variable)[] = (currentForm.variables ?? []).map(apiVar => {
+        const stagingVar = savingState.variables!.find(sv => sv.name === apiVar.name);
+        if (!stagingVar) return apiVar;
+
+        if ('expression' in apiVar) {
+          // Resolve the original name before any pending rename to look up the baseline expression.
+          const originalName = renames.find(r => r.to === stagingVar.name)?.from ?? stagingVar.name;
+          const originalExpression = (form.variables?.find(v => v.name === originalName) as Variable | undefined)?.expression ?? '';
+          const stagedExpression = (stagingVar as Variable).expression;
+
+          const mergedExpression = stagedExpression !== originalExpression
+            ? applyRenamesToExpression(stagedExpression ?? '')
+            : (apiVar as Variable).expression;
+
+          return { ...stagingVar, expression: mergedExpression } as Variable;
+        }
+        return stagingVar;
+      });
+
+      setForm(currentForm);
+      applyVariableList(mergedVariables);
+      // Sync both baselines so hasChanges returns false after save.
+      resetVariables(mergedVariables);
+      resetItems(currentForm.data);
+      if (latestRev) {
+        setRevision(latestRev);
+      }
+    } else {
       applyVariableChanges(savingState);
     }
+
+    clearPendingRenames();
   }
 
   return (

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingAction.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingAction.ts
@@ -2,7 +2,8 @@ import {
   DialobItemTemplate, ValueSetEntry, ValidationRule, LocalizedString,
   ContextVariableType,
   ContextVariable,
-  Variable
+  Variable,
+  DialobItems
 } from "../../../types";
 import { TranslationResult } from "../../../backend/types";
 
@@ -41,6 +42,10 @@ export type SavingAction =
   | { type: 'deleteVariable', variableId: string }
   | { type: 'moveVariable', origin: ContextVariable | Variable, destination: ContextVariable | Variable }
   | { type: 'changeVariableId', variables: (ContextVariable | Variable)[] }
+  | { type: 'updateVariableName', currentName: string, originalName: string, to: string }
+  | { type: 'clearPendingRenames' }
+  | { type: 'resetItems', items: DialobItems }
+  | { type: 'resetVariables', variables: (ContextVariable | Variable)[] }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | { type: 'setMetadataValue', attr: string, value: any }
   | { type: 'applyTranslations', translations: TranslationResult[], sourceLanguage: string, targetLanguage: string }

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingContext.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingContext.tsx
@@ -2,6 +2,11 @@ import { createContext, Dispatch } from "react";
 import { ComposerMetadata, ContextVariable, DialobItem, DialobItems, FormMetadata, ValueSet, Variable } from "../../../types";
 import { SavingAction } from "./SavingAction";
 
+export interface VariableRename {
+  from: string;
+  to: string;
+}
+
 export interface SavingState {
   item?: DialobItem;
   valueSets?: ValueSet[];
@@ -9,6 +14,7 @@ export interface SavingState {
   variables?: (ContextVariable | Variable)[];
   formMetadata?: FormMetadata;
   items?: DialobItems;
+  pendingVariableRenames?: VariableRename[];
 }
 
 export const SavingContext = createContext<{ state: SavingState, dispatch: Dispatch<SavingAction> }>({

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/reducer.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/reducer.ts
@@ -1,5 +1,5 @@
 import { produce } from "immer";
-import { ContextVariable, ContextVariableType, DialobItemTemplate, LocalizedString, TranslationMetadata, ValidationRule, ValueSetEntry, Variable } from "../../../types";
+import { ContextVariable, ContextVariableType, DialobItems, DialobItemTemplate, LocalizedString, TranslationMetadata, ValidationRule, ValueSetEntry, Variable } from "../../../types";
 import { cleanLocalizedString, cleanString } from "../../../utils/StringUtils";
 import { SavingAction } from "./SavingAction";
 import { SavingState } from "./SavingContext";
@@ -445,6 +445,52 @@ const moveVariable = (state: SavingState, origin: ContextVariable | Variable, de
   }
 }
 
+const updateVariableName = (state: SavingState, currentName: string, originalName: string, to: string): void => {
+  if (!state.variables) return;
+
+  const varIdx = state.variables.findIndex(v => v.name === currentName);
+  if (varIdx === -1) return;
+
+  state.variables[varIdx].name = to;
+
+  if (state.items) {
+    Object.values(state.items).forEach(item => {
+      if (item.type === 'rowgroup' && item.items?.includes(currentName)) {
+        const idx = item.items.indexOf(currentName);
+        if (idx > -1) {
+          item.items[idx] = to;
+        }
+      }
+    });
+  }
+
+  if (!state.pendingVariableRenames) {
+    state.pendingVariableRenames = [];
+  }
+  const existingIdx = state.pendingVariableRenames.findIndex(r => r.from === originalName);
+  if (existingIdx > -1) {
+    if (to === originalName) {
+      state.pendingVariableRenames.splice(existingIdx, 1);
+    } else {
+      state.pendingVariableRenames[existingIdx].to = to;
+    }
+  } else if (to !== originalName) {
+    state.pendingVariableRenames.push({ from: originalName, to });
+  }
+}
+
+const clearPendingRenames = (state: SavingState): void => {
+  state.pendingVariableRenames = [];
+}
+
+const resetItems = (state: SavingState, items: DialobItems): void => {
+  state.items = items;
+}
+
+const resetVariables = (state: SavingState, variables: (ContextVariable | Variable)[]): void => {
+  state.variables = variables;
+}
+
 const changeVariableId = (state: SavingState, variables: (ContextVariable | Variable)[]): void => {
   if (state.variables && state.items) {
     // Build a map of old variable names to new variable names
@@ -645,6 +691,14 @@ export const itemReducer = (state: SavingState, action: SavingAction): SavingSta
       moveVariable(state, action.origin, action.destination);
     } else if (action.type === 'changeVariableId') {
       changeVariableId(state, action.variables);
+    } else if (action.type === 'updateVariableName') {
+      updateVariableName(state, action.currentName, action.originalName, action.to);
+    } else if (action.type === 'clearPendingRenames') {
+      clearPendingRenames(state);
+    } else if (action.type === 'resetItems') {
+      resetItems(state, action.items);
+    } else if (action.type === 'resetVariables') {
+      resetVariables(state, action.variables);
     } else if (action.type === 'setMetadataValue') {
       setMetadataValue(state, action.attr, action.value);
     } else if (action.type === 'applyTranslations') {

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/useSave.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/useSave.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { SavingContext } from './SavingContext';
-import { ContextVariable, ContextVariableType, DialobItemTemplate, LocalizedString, ValidationRule, ValueSetEntry, Variable } from '../../../types';
+import { ContextVariable, ContextVariableType, DialobItems, DialobItemTemplate, LocalizedString, ValidationRule, ValueSetEntry, Variable } from '../../../types';
 import { TranslationResult } from '../../../backend/types';
 
 export const useSave = () => {
@@ -121,6 +121,22 @@ export const useSave = () => {
     dispatch({ type: 'changeVariableId', variables });
   }
 
+  const updateVariableName = (currentName: string, originalName: string, to: string) => {
+    dispatch({ type: 'updateVariableName', currentName, originalName, to });
+  }
+
+  const clearPendingRenames = () => {
+    dispatch({ type: 'clearPendingRenames' });
+  }
+
+  const resetItems = (items: DialobItems) => {
+    dispatch({ type: 'resetItems', items });
+  }
+
+  const resetVariables = (variables: (ContextVariable | Variable)[]) => {
+    dispatch({ type: 'resetVariables', variables });
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const setMetadataValue = (attr: string, value: any) => {
     dispatch({ type: 'setMetadataValue', attr, value });
@@ -167,6 +183,10 @@ export const useSave = () => {
     deleteVariable,
     moveVariable,
     changeVariableId,
+    updateVariableName,
+    clearPendingRenames,
+    resetItems,
+    resetVariables,
     setMetadataValue,
     applyTranslations,
     addAITranslation,


### PR DESCRIPTION
Editing choice items and variables is redesigned to have an expandable row editor. Clicking on the edit icon opens up the expanded row where the user can make changes for each of the cells (including id change). All changes made are saved using the dialog save button.

New choice editor:
<img width="1552" height="659" alt="image" src="https://github.com/user-attachments/assets/85819c27-1c07-4c81-b842-2eb72590bfbf" />
<img width="1347" height="225" alt="image" src="https://github.com/user-attachments/assets/230ec7ae-ab51-4349-85ad-9146adeb7e53" />

New variables editor:
<img width="1211" height="646" alt="image" src="https://github.com/user-attachments/assets/6f1fcf1f-8dad-4356-9e80-34ac96ee8eba" />
<img width="1211" height="652" alt="image" src="https://github.com/user-attachments/assets/188339dc-1f29-4f67-892f-a9cb42fd8d7c" />


