### PR TITLE
fix(engine): properly resolve scoped variables in localized labels

### DIFF
--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperator.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperator.java
@@ -22,7 +22,6 @@ import io.dialob.session.engine.program.ProgramBuilder;
 import io.dialob.session.engine.program.model.Expression;
 import io.dialob.session.engine.program.model.Label;
 import io.dialob.session.engine.session.command.EventMatcher;
-import io.dialob.session.engine.session.model.IdUtils;
 import io.dialob.session.engine.session.model.ItemId;
 import io.dialob.session.engine.session.model.ValueSetId;
 import org.apache.commons.lang3.StringUtils;
@@ -62,7 +61,8 @@ public record LocalizedLabelOperator(
         if (matcher.group(1) == null) {
           expressions.add(Constant.builder().value(matcher.group(0)).valueType(ValueType.STRING).build());
         } else {
-          String itemId = matcher.group(1);
+          ItemId itemId = programBuilder.findItemBuilder(matcher.group(1))
+            .get().getId();
           var variableReference = Operators.var(itemId, ValueType.STRING);
           String format = matcher.group(2);
           if (StringUtils.isNotBlank(format)) {
@@ -73,16 +73,16 @@ public record LocalizedLabelOperator(
                 expressions.add(ToStringOperator.of(variableReference));
                 break;
               case "lowercase":
-                expressions.add(lowerCaseOf(toStringExpression(programBuilder, IdUtils.toId(itemId), variableReference)));
+                expressions.add(lowerCaseOf(toStringExpression(programBuilder, itemId, variableReference)));
                 break;
               case "uppercase":
-                expressions.add(upperCaseOf(toStringExpression(programBuilder, IdUtils.toId(itemId), variableReference)));
+                expressions.add(upperCaseOf(toStringExpression(programBuilder, itemId, variableReference)));
                 break;
               default:
                 expressions.add(FormatOperator.of(variableReference, format));
             }
           } else {
-            expressions.add(toStringExpression(programBuilder, IdUtils.toId(itemId), variableReference));
+            expressions.add(toStringExpression(programBuilder, itemId, variableReference));
           }
         }
         i = matcher.end();

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/arith/Operators.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/arith/Operators.java
@@ -83,7 +83,4 @@ public interface Operators {
   static VariableReference<?> var(@NonNull ItemId id, @NonNull ValueType valueType) {
     return new VariableReference.Builder<>().itemId(id).valueType(valueType).build();
   }
-  static VariableReference<?> var(@NonNull String id, @NonNull ValueType valueType) {
-    return var(ref(id), valueType);
-  }
 }

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/AbstractDialobProgramTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/AbstractDialobProgramTest.java
@@ -260,7 +260,17 @@ public abstract class AbstractDialobProgramTest {
       }
     }
     Assertions.fail("Error " + itemId + "." + errorCode + " not found");
+  }
 
+  protected void assertLabel(final DialobSession session, final ItemId itemId, String label) {
+    final Collection<ItemState> errorStates = session.itemStates().values();
+    for (var state : errorStates) {
+      if (state.id().equals(itemId)) {
+        Assertions.assertEquals(label, state.label());
+        return;
+      }
+    }
+    Assertions.fail("Label " + itemId + " not found");
   }
 
   protected ItemId toRef(String id) {

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/DialobProgramFromFormCompilerTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/DialobProgramFromFormCompilerTest.java
@@ -235,6 +235,74 @@ class DialobProgramFromFormCompilerTest extends AbstractDialobProgramTest {
     Mockito.verifyNoMoreInteractions(functionRegistry);
   }
 
+  @Test
+  void shouldCalculateExpressionVariablesInRowgroupsContextAndUpdateLabels() {
+    FunctionRegistry functionRegistry = Mockito.mock(FunctionRegistry.class);
+    DialobSessionEvalContextFactory sessionContextFactory = new DialobSessionEvalContextFactory(functionRegistry, null);
+    DialobProgramFromFormCompiler compiler = new DialobProgramFromFormCompiler(functionRegistry);
+
+    DialobProgram dialobProgram = compiler.compileForm(new Form.Builder()
+      .id("123")
+      .name("123")
+      .putData("questionnaire", new FormItem.Builder()
+        .id("questionnaire")
+        .type("questionnaire")
+        .addItems("g")
+        .build())
+      .putData("g", new FormItem.Builder()
+        .id("g")
+        .type("group")
+        .addItems("rg")
+        .build())
+      .putData("rg", new FormItem.Builder()
+        .id("rg")
+        .type("rowgroup")
+        .addItems("q1","q2","info","summa")
+        .build())
+      .putData("q1", new FormItem.Builder()
+        .id("q1")
+        .type("number")
+        .build())
+      .putData("q2", new FormItem.Builder()
+        .id("q2")
+        .type("number")
+        .build())
+      .putData("info", new FormItem.Builder()
+        .id("info")
+        .type("note")
+        .label(Map.of("fi", "Summa on {summa}"))
+        .build())
+      .addVariables(new Variable.Builder()
+        .name("summa")
+        .context(false)
+        .expression("q1 + q2")
+        .build())
+      .metadata(new Form.Metadata.Builder()
+        .label("xxx")
+        .putAdditionalProperties("answersRequiredByDefault", true)
+        .build())
+      .build());
+
+    DialobSession session = dialobProgram.createSession(sessionContextFactory, null, null, "fi", null);
+    assertNotNull(session);
+    DialobSessionUpdater dialobSessionUpdater = sessionContextFactory.createSessionUpdater(dialobProgram, session, false);
+
+    dialobSessionUpdater.applyCommands(toCommands(addRow(toRef("rg"))));
+    assertVariableEquals(session, null, toRef("rg.0.summa"));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q1"), "1")));
+    assertActive(session, toRef("rg.0.info"));
+    assertLabel(session, toRef("rg.0.info"), "Summa on null");
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q2"), "2")));
+//    assertActive(session, toRef("rg.0.q3"));
+    assertVariableEquals(session, BigInteger.valueOf(3), toRef("rg.0.summa"));
+    assertLabel(session, toRef("rg.0.info"), "Summa on 3");
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q2"), null)));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("rg.0.q1"), null)));
+    assertVariableEquals(session, null, toRef("rg.0.summa"));
+
+    Mockito.verifyNoMoreInteractions(functionRegistry);
+  }
+
 
 
   @Test

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperatorTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperatorTest.java
@@ -15,6 +15,7 @@
  */
 package io.dialob.session.engine.program.expr.arith;
 
+import io.dialob.session.engine.program.AbstractItemBuilder;
 import io.dialob.session.engine.program.EvalContext;
 import io.dialob.session.engine.program.ProgramBuilder;
 import io.dialob.session.engine.program.expr.OutputFormatter;
@@ -74,11 +75,16 @@ class LocalizedLabelOperatorTest {
 
   @Test
   void shouldExpandVariablesNonExistentExapndsToNull() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1}")));
     when(context.getLanguage()).thenReturn("fi");
     assertEquals("Otsikko null", operator.eval(context));
     verify(context, times(1)).getLanguage();
     verify(context).getItemValue(ref("var1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verifyNoMoreInteractions(programBuilder, context);
   }
@@ -90,12 +96,17 @@ class LocalizedLabelOperatorTest {
 
   @Test
   void shouldExpandStringVariables() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1}")));
     when(context.getLanguage()).thenReturn("fi");
     when(context.getItemValue(ref("var1"))).thenReturn("hello");
     assertEquals("Otsikko hello", operator.eval(context));
     verify(context, times(1)).getLanguage();
     verify(context).getItemValue(ref("var1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verify(context).getOutputFormatter();
     verifyNoMoreInteractions(programBuilder, context);
@@ -103,26 +114,40 @@ class LocalizedLabelOperatorTest {
 
   @Test
   void shouldExpandNumberVariablesWithFormmater() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1:#,##0}")));
     when(context.getLanguage()).thenReturn("fi");
     when(context.getItemValue(ref("var1"))).thenReturn(123000);
     assertEquals("Otsikko 123 000", operator.eval(context));
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verifyNoMoreInteractions(programBuilder, context);
   }
   @Test
   void shouldExpandDecimalVariablesWithFormmater() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1:#,##0.00}")));
     when(context.getLanguage()).thenReturn("fi");
     when(context.getItemValue(ref("var1"))).thenReturn(BigDecimal.valueOf(123000));
     assertEquals("Otsikko 123 000,00", operator.eval(context));
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verifyNoMoreInteractions(programBuilder, context);
   }
   @Test
   void shouldExpandNumberlVariablesWithoutFormmater() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1}")));
     when(context.getLanguage()).thenReturn("fi");
     when(context.getItemValue(ref("var1"))).thenReturn(123000);
@@ -130,11 +155,16 @@ class LocalizedLabelOperatorTest {
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
     verify(context).getOutputFormatter();
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verifyNoMoreInteractions(programBuilder, context);
   }
   @Test
   void shouldExpandDecimallVariablesWithoutFormmater() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1}")));
     when(context.getLanguage()).thenReturn("fi");
     when(context.getItemValue(ref("var1"))).thenReturn(BigDecimal.valueOf(123000.01));
@@ -142,11 +172,16 @@ class LocalizedLabelOperatorTest {
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
     verify(context).getOutputFormatter();
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verifyNoMoreInteractions(programBuilder, context);
   }
   @Test
   void shouldInterpolateSelectionToValue() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     when(programBuilder.findValueSetIdForItem(IdUtils.toId("var1"))).thenReturn(Optional.of("vs1"));
 
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1}")));
@@ -159,12 +194,17 @@ class LocalizedLabelOperatorTest {
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
     verify(context).getValueSetState(new ValueSetId("vs1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verify(valueSet).entries();
     verifyNoMoreInteractions(programBuilder, context, valueSet);
   }
   @Test
   void shouldInterpolateSelectionToLowerCaseValue() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     when(programBuilder.findValueSetIdForItem(IdUtils.toId("var1"))).thenReturn(Optional.of("vs1"));
 
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1:lowercase}")));
@@ -177,6 +217,7 @@ class LocalizedLabelOperatorTest {
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
     verify(context).getValueSetState(new ValueSetId("vs1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verify(valueSet).entries();
     verifyNoMoreInteractions(programBuilder, context, valueSet);
@@ -184,6 +225,9 @@ class LocalizedLabelOperatorTest {
 
   @Test
   void shouldInterpolateSelectionToUpperCaseValue() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
     when(programBuilder.findValueSetIdForItem(IdUtils.toId("var1"))).thenReturn(Optional.of("vs1"));
 
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1:uppercase}")));
@@ -196,12 +240,17 @@ class LocalizedLabelOperatorTest {
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
     verify(context).getValueSetState(new ValueSetId("vs1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verify(valueSet).entries();
     verifyNoMoreInteractions(programBuilder, context, valueSet);
   }
   @Test
   void shouldInterpolateSelectionToKeyWhenFormatIsKey() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1:key}")));
     when(context.getLanguage()).thenReturn("fi");
     when(context.getItemValue(ref("var1"))).thenReturn("x1");
@@ -209,11 +258,16 @@ class LocalizedLabelOperatorTest {
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
     verify(context).getOutputFormatter();
+    verify(programBuilder).findItemBuilder(anyString());
     verifyNoMoreInteractions(programBuilder, context);
   }
 
   @Test
   void shouldInterpolateMultichoiceSelectionToValue() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
     when(programBuilder.findValueSetIdForItem(IdUtils.toId("var1"))).thenReturn(Optional.of("vs1"));
 
     LocalizedLabelOperator operator = LocalizedLabelOperator.createLocalizedLabelOperator(programBuilder, Label.of(Map.of("fi","Otsikko {var1}")));
@@ -232,6 +286,7 @@ class LocalizedLabelOperatorTest {
     verify(context, atLeastOnce()).getLanguage();
     verify(context).getItemValue(ref("var1"));
     verify(context).getValueSetState(new ValueSetId("vs1"));
+    verify(programBuilder).findItemBuilder(anyString());
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verify(valueSet).entries();
     verifyNoMoreInteractions(programBuilder, context, valueSet);

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/session/command/CommandFactoryTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/session/command/CommandFactoryTest.java
@@ -108,7 +108,7 @@ class CommandFactoryTest {
   void shouldNotTriggerItself() {
     ItemId itemId = IdUtils.toId("q1");
     Expression expression =
-      Operators.and(Operators.isActive(itemId), new NumberOperators().lt(Operators.var("q1", ValueType.INTEGER), Constant.builder().valueType(ValueType.INTEGER).value(0).build()));
+      Operators.and(Operators.isActive(itemId), new NumberOperators().lt(Operators.var(IdUtils.toId("q1"), ValueType.INTEGER), Constant.builder().valueType(ValueType.INTEGER).value(0).build()));
     //;
     var updateValidationCommand = CommandFactory.updateValidationCommand(new ErrorId(itemId, "err"), expression);
     Set<EventMatcher> eventMatchers = updateValidationCommand.eventMatchers();


### PR DESCRIPTION
- Update LocalizedLabelOperator to resolve ItemIds via ProgramBuilder instead of parsing raw strings, enabling correct variable interpolation within rowgroups.
- Remove string-based Operators.var() to enforce strict ItemId usage across the engine.
- Add test asserting variable calculation and label updates within a rowgroup context.