### PR TITLE
Function for string formatting in expression variables

### DIFF
--- a/dialob-components/dialob-rule-parser/src/main/java/io/dialob/rule/parser/ParserUtil.java
+++ b/dialob-components/dialob-rule-parser/src/main/java/io/dialob/rule/parser/ParserUtil.java
@@ -21,6 +21,8 @@ import io.dialob.rule.parser.api.ValueType;
 
 public final class ParserUtil {
 
+  public static final String FORMAT_FUNCTION = "format";
+
   private ParserUtil() {}
 
   public static boolean isReducerOperator(@NonNull String reducer) {
@@ -29,6 +31,10 @@ public final class ParserUtil {
       || "maxOf".equals(reducer)
       || "allOf".equals(reducer)
       || "anyOf".equals(reducer);
+  }
+
+  public static boolean isFormatFunction(@NonNull String name) {
+    return FORMAT_FUNCTION.equals(name);
   }
 
   public static ValueType itemTypeToValueType(@NonNull String itemType) {

--- a/dialob-components/dialob-rule-parser/src/main/java/io/dialob/rule/parser/api/CompilerErrorCode.java
+++ b/dialob-components/dialob-rule-parser/src/main/java/io/dialob/rule/parser/api/CompilerErrorCode.java
@@ -53,4 +53,7 @@ public class CompilerErrorCode {
   public static final String ARRAY_TYPE_EXPECTED = "ARRAY_TYPE_EXPECTED";
   public static final String ARRAY_TYPE_UNEXPECTED = "ARRAY_TYPE_UNEXPECTED";
 
+  public static final String FORMAT_ARGUMENT_MUST_BE_CONSTANT = "FORMAT_ARGUMENT_MUST_BE_CONSTANT";
+  public static final String UNKNOWN_FORMAT_ITEM = "UNKNOWN_FORMAT_ITEM";
+
 }

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/ProgramBuilder.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/ProgramBuilder.java
@@ -87,7 +87,7 @@ public class ProgramBuilder implements ExpressionCompiler, BuilderParent, Builde
 
   public ProgramBuilder(@NonNull FunctionRegistry functionRegistry) {
     this.functionRegistry = functionRegistry;
-    this.operatorFactory = new DDRLOperatorFactory();
+    this.operatorFactory = new DDRLOperatorFactory(this);
   }
 
   protected void addItem(Item item) {
@@ -383,6 +383,9 @@ public class ProgramBuilder implements ExpressionCompiler, BuilderParent, Builde
           return argTypes[0].getItemValueType();
         }
         return argTypes[0];
+      }
+      if (ParserUtil.isFormatFunction(functionName)) {
+        return ValueType.STRING;
       }
       return functionRegistry.returnTypeOf(functionName, argTypes);
     }

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/DDRLOperatorFactory.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/DDRLOperatorFactory.java
@@ -16,8 +16,11 @@
 package io.dialob.session.engine.program.expr;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.dialob.rule.parser.ParserUtil;
 import io.dialob.rule.parser.api.CompilerErrorCode;
 import io.dialob.rule.parser.api.ValueType;
+import io.dialob.session.engine.program.ProgramBuilder;
 import io.dialob.session.engine.program.expr.arith.*;
 import io.dialob.session.engine.program.model.Expression;
 import io.dialob.session.engine.session.model.ItemId;
@@ -28,6 +31,17 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 public class DDRLOperatorFactory implements OperatorFactory {
+
+  @Nullable
+  private final ProgramBuilder programBuilder;
+
+  public DDRLOperatorFactory() {
+    this(null);
+  }
+
+  public DDRLOperatorFactory(@Nullable ProgramBuilder programBuilder) {
+    this.programBuilder = programBuilder;
+  }
 
   private static final DecimalOperators DECIMAL_OPERATORS = new DecimalOperators();
   private static final NumberOperators NUMBER_OPERATORS = new NumberOperators();
@@ -71,6 +85,9 @@ public class DDRLOperatorFactory implements OperatorFactory {
   @NonNull
   public Expression createOperator(@NonNull ValueType nodeValueType, @NonNull String operator, @NonNull List<Expression> arguments) {
     Expression expr;
+    if (ParserUtil.isFormatFunction(operator)) {
+      return createFormatOperator(arguments);
+    }
     final OperatorSymbol operatorSymbol = OperatorSymbol.mapOp(operator);
     if (operatorSymbol == null) {
       return createFunctionInvocation(nodeValueType, operator, arguments);
@@ -186,6 +203,21 @@ public class DDRLOperatorFactory implements OperatorFactory {
       throw new MatcherRegexErrorException(CompilerErrorCode.MATCHER_DYNAMIC_REGEX, null);
     }
     return patternExpr;
+  }
+
+  @NonNull
+  private Expression createFormatOperator(@NonNull List<Expression> arguments) {
+    if (arguments.size() != 1 || !(arguments.getFirst() instanceof Constant<?> constant) || constant.getValueType() != ValueType.STRING) {
+      throw new FormatExpressionException(CompilerErrorCode.FORMAT_ARGUMENT_MUST_BE_CONSTANT);
+    }
+    if (programBuilder == null) {
+      throw new FormatExpressionException(CompilerErrorCode.COMPILER_ERROR);
+    }
+    String template = (String) constant.value();
+    if (template == null) {
+      return Constant.builder().value("").valueType(ValueType.STRING).build();
+    }
+    return LocalizedLabelOperator.createFormatExpression(programBuilder, template);
   }
 
   @NonNull

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/FormatExpressionException.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/FormatExpressionException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 - 2025 ReSys (info@dialob.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dialob.session.engine.program.expr;
+
+import io.dialob.session.engine.program.ProgramBuilderException;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FormatExpressionException extends ProgramBuilderException {
+
+  private final transient List<Object> args;
+
+  public FormatExpressionException(String code, Object... args) {
+    super(code);
+    this.args = List.of(args);
+  }
+
+  @Override
+  public List<Object> getArgs() {
+    return args;
+  }
+
+}

--- a/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperator.java
+++ b/dialob-components/dialob-session-engine/src/main/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperator.java
@@ -16,9 +16,11 @@
 package io.dialob.session.engine.program.expr.arith;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import io.dialob.rule.parser.api.CompilerErrorCode;
 import io.dialob.rule.parser.api.ValueType;
 import io.dialob.session.engine.program.EvalContext;
 import io.dialob.session.engine.program.ProgramBuilder;
+import io.dialob.session.engine.program.expr.FormatExpressionException;
 import io.dialob.session.engine.program.model.Expression;
 import io.dialob.session.engine.program.model.Label;
 import io.dialob.session.engine.session.command.EventMatcher;
@@ -97,6 +99,21 @@ public record LocalizedLabelOperator(
     });
 
     return LocalizedLabelOperator.of(value);
+  }
+
+  public static Expression createFormatExpression(@NonNull ProgramBuilder programBuilder, @NonNull String template) {
+    final String formatKey = "__dialob_format__";
+    final LocalizedLabelOperator operator;
+    try {
+      operator = createLocalizedLabelOperator(programBuilder, Label.of(Collections.singletonMap(formatKey, template)));
+    } catch (NoSuchElementException e) {
+      throw new FormatExpressionException(CompilerErrorCode.UNKNOWN_FORMAT_ITEM);
+    }
+    Expression expression = operator.value().get(formatKey);
+    if (expression == null) {
+      return Constant.builder().value("").valueType(ValueType.STRING).build();
+    }
+    return expression;
   }
 
   public static LocalizedLabelOperator of(Map<String, Expression> value) {

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/DialobProgramFromFormCompilerTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/DialobProgramFromFormCompilerTest.java
@@ -303,6 +303,56 @@ class DialobProgramFromFormCompilerTest extends AbstractDialobProgramTest {
     Mockito.verifyNoMoreInteractions(functionRegistry);
   }
 
+  @Test
+  void shouldExpandFormatFunctionInExpressionVariable() {
+    FunctionRegistry functionRegistry = Mockito.mock(FunctionRegistry.class);
+    DialobSessionEvalContextFactory sessionContextFactory = new DialobSessionEvalContextFactory(functionRegistry, null);
+    DialobProgramFromFormCompiler compiler = new DialobProgramFromFormCompiler(functionRegistry);
+
+    DialobProgram dialobProgram = compiler.compileForm(new Form.Builder()
+      .id("123")
+      .name("123")
+      .putData("questionnaire", new FormItem.Builder()
+        .id("questionnaire")
+        .type("questionnaire")
+        .addItems("g")
+        .build())
+      .putData("g", new FormItem.Builder()
+        .id("g")
+        .type("group")
+        .addItems("q1", "q2")
+        .build())
+      .putData("q1", new FormItem.Builder()
+        .id("q1")
+        .type("text")
+        .build())
+      .putData("q2", new FormItem.Builder()
+        .id("q2")
+        .type("number")
+        .build())
+      .addVariables(new Variable.Builder()
+        .name("summary")
+        .context(false)
+        .expression("format('Hello {q1}, total {q2}')")
+        .build())
+      .metadata(new Form.Metadata.Builder()
+        .label("xxx")
+        .build())
+      .build());
+
+    DialobSession session = dialobProgram.createSession(sessionContextFactory, null, null, "fi", null);
+    assertNotNull(session);
+    DialobSessionUpdater dialobSessionUpdater = sessionContextFactory.createSessionUpdater(dialobProgram, session, false);
+
+    assertVariableEquals(session, "Hello null, total null", toRef("summary"));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("q1"), "World")));
+    assertVariableEquals(session, "Hello World, total null", toRef("summary"));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("q2"), "5")));
+    assertVariableEquals(session, "Hello World, total 5", toRef("summary"));
+    dialobSessionUpdater.applyCommands(toCommands(answer(toRef("q1"), null)));
+    assertVariableEquals(session, "Hello null, total 5", toRef("summary"));
+  }
+
 
 
   @Test

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/expr/DDRLOperatorFactoryTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/expr/DDRLOperatorFactoryTest.java
@@ -257,4 +257,32 @@ class DDRLOperatorFactoryTest {
     assertInstanceOf(FunctionCallOperator.class, func);
   }
 
+  @Test
+  void shouldRejectNonConstantFormatArgument() {
+    DDRLOperatorFactory factory = new DDRLOperatorFactory();
+    Expression arg = VariableReference.of(IdUtils.toId("var1"), ValueType.STRING);
+
+    assertThrows(FormatExpressionException.class,
+      () -> factory.createOperator(ValueType.STRING, "format", List.of(arg)));
+  }
+
+  @Test
+  void shouldRejectNonStringConstantFormatArgument() {
+    DDRLOperatorFactory factory = new DDRLOperatorFactory();
+    Expression arg = new Constant<>(1, ValueType.INTEGER);
+
+    assertThrows(FormatExpressionException.class,
+      () -> factory.createOperator(ValueType.STRING, "format", List.of(arg)));
+  }
+
+  @Test
+  void shouldRejectFormatWithWrongArgumentCount() {
+    DDRLOperatorFactory factory = new DDRLOperatorFactory();
+    Expression arg1 = new Constant<>("a", ValueType.STRING);
+    Expression arg2 = new Constant<>("b", ValueType.STRING);
+
+    assertThrows(FormatExpressionException.class,
+      () -> factory.createOperator(ValueType.STRING, "format", List.of(arg1, arg2)));
+  }
+
 }

--- a/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperatorTest.java
+++ b/dialob-components/dialob-session-engine/src/test/java/io/dialob/session/engine/program/expr/arith/LocalizedLabelOperatorTest.java
@@ -18,7 +18,9 @@ package io.dialob.session.engine.program.expr.arith;
 import io.dialob.session.engine.program.AbstractItemBuilder;
 import io.dialob.session.engine.program.EvalContext;
 import io.dialob.session.engine.program.ProgramBuilder;
+import io.dialob.session.engine.program.expr.FormatExpressionException;
 import io.dialob.session.engine.program.expr.OutputFormatter;
+import io.dialob.session.engine.program.model.Expression;
 import io.dialob.session.engine.program.model.Label;
 import io.dialob.session.engine.session.model.IdUtils;
 import io.dialob.session.engine.session.model.ItemId;
@@ -34,7 +36,9 @@ import java.math.BigDecimal;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 class LocalizedLabelOperatorTest {
@@ -290,6 +294,32 @@ class LocalizedLabelOperatorTest {
     verify(programBuilder).findValueSetIdForItem(any(ItemId.class));
     verify(valueSet).entries();
     verifyNoMoreInteractions(programBuilder, context, valueSet);
+  }
+
+  @Test
+  void createFormatExpressionExpandsPlaceholdersLikeLabels() {
+    AbstractItemBuilder<?,ProgramBuilder> itemBuilder = Mockito.mock();
+    when(programBuilder.findItemBuilder("var1")).thenReturn(Optional.of(itemBuilder));
+    when(itemBuilder.getId()).thenReturn(IdUtils.toId("var1"));
+
+    Expression expression = LocalizedLabelOperator.createFormatExpression(programBuilder, "Otsikko {var1}");
+    assertInstanceOf(ConcatOperator.class, expression);
+    when(context.getItemValue(ref("var1"))).thenReturn("hello");
+    assertEquals("Otsikko hello", expression.eval(context));
+  }
+
+  @Test
+  void createFormatExpressionWithoutContentReturnsEmptyConstant() {
+    Expression expression = LocalizedLabelOperator.createFormatExpression(programBuilder, "");
+    assertInstanceOf(Constant.class, expression);
+    assertEquals("", expression.eval(context));
+  }
+
+  @Test
+  void createFormatExpressionThrowsOnUnknownItem() {
+    when(programBuilder.findItemBuilder("nope")).thenReturn(Optional.empty());
+    assertThrows(FormatExpressionException.class,
+      () -> LocalizedLabelOperator.createFormatExpression(programBuilder, "Value {nope}"));
   }
 
 }

--- a/dialob-docusaurus/docs/05-dialob-expression-language-del.md
+++ b/dialob-docusaurus/docs/05-dialob-expression-language-del.md
@@ -255,6 +255,16 @@ The behaviour of these two operators can be seen in how questions are displayed 
 
 * **`isIban()` , `isNotIban()`**: Used for validating IBAN numbers. Can contain spaces.
 
+* **`format(*Text*)`**: Builds a string by interpolating item values into a template, using the same `{itemId}` placeholder syntax as note and question labels. The argument must be a string literal. Return type is *Text*. This is typically used in expression variables to concatenate strings together with answer values.
+
+  The template supports the same placeholder formats as labels:
+  * `{itemId}` inserts the value of the item (for choice items, the selected entry's label).
+  * `{itemId:key}` inserts the raw stored key of a choice item rather than its label.
+  * `{itemId:uppercase}` / `{itemId:lowercase}` change the case of the inserted value.
+  * `{itemId:#,##0.00}` formats a number with a custom decimal pattern.
+
+  Example expression variable value: `format('Hello {firstName}, your total is {total:#,##0} euros')`. The variable automatically recomputes whenever any referenced item value changes. Note that placeholders reference items by ID only; to interpolate a calculated value, define an expression variable for it and reference that variable's ID (for example `{sum}`, not `{q1 + q2}`).
+
 **NOTE**: Although the list of inbuilt functions can be extended via Java or Groovy, users should consider using service requests instead as an alternative to functions. This especially true in cases where the scope of functions is growing larger and more complex.  
 
 ---
@@ -279,7 +289,7 @@ Language specification follows ISO-639-1 two-character abbreviations. [See list 
 | `or`              |  `today()`          |                 |
 | `true`            |  `week`             |                 |
 | `valid`           |  `weeks`            |                 |
-|                   |  `year`             |                 |
+| `format`        |  `year`             |                 |
 |                   |  `years`            |                 |
 
 ---

--- a/frontend/dialob-composer-material/src/components/code/language.ts
+++ b/frontend/dialob-composer-material/src/components/code/language.ts
@@ -8,6 +8,7 @@ export const RESERVED_WORDS: Completion[] = [
   { label: 'or', type: 'keyword' },
   { label: 'true', type: 'keyword' },
   { label: 'false', type: 'keyword' },
+  { label: 'format', type: 'function' },
   { label: 'matches', type: 'function' },
   { label: 'today', type: 'function' },
   { label: 'now', type: 'function' },

--- a/frontend/dialob-composer-material/src/intl/en.ts
+++ b/frontend/dialob-composer-material/src/intl/en.ts
@@ -336,6 +336,8 @@ const en = {
   'errors.message.ARRAY_TYPE_EXPECTED': 'Array type expected',
   'errors.message.ARRAY_TYPE_UNEXPECTED': 'Array type unexpected',
   'errors.message.FORM_SOURCE_ITEM_NOT_FOUND': 'Form source item not found',
+  'errors.message.FORMAT_ARGUMENT_MUST_BE_CONSTANT': 'format() argument must be a string literal',
+  'errors.message.UNKNOWN_FORMAT_ITEM': 'Unknown item in format() template',
 
   'markdownEditor.format': 'Format',
   'markdownEditor.list': 'List',

--- a/frontend/dialob-fill-demo-material/README.md
+++ b/frontend/dialob-fill-demo-material/README.md
@@ -1,5 +1,60 @@
 # Dialob Material UI Fill: Generic App
 
+## Running the fill app locally (against the dev-env backend)
+
+To preview forms locally by clicking **Preview** in the Composer, the fill app
+and the backend `dialob-session` service need a few configuration changes.
+
+### 1. App endpoint and session id (`.env`)
+
+The app reads its backend endpoint and (optionally) a fixed session id from
+`frontend/dialob-fill-demo-material/.env`:
+
+```bash
+VITE_DIALOB_ENDPOINT=http://localhost:8084/session/dialob
+VITE_DIALOB_SESSION_ID=
+```
+
+- `VITE_DIALOB_ENDPOINT` points at the local `dialob-session` service.
+- `VITE_DIALOB_SESSION_ID` **must be left empty**. When empty, the app reads the
+  session id from the URL hash (e.g. `http://localhost:3001/#/<sessionId>`),
+  which is how Composer's Preview button opens a form. If it is set to a fixed
+  value (such as `00000000-0000-0000-0000-000000000000`), the app ignores the
+  hash and tries to load that id instead.
+
+### 2. Enable CORS on the session service (`dev-env/.env.session`)
+
+The browser blocks the fill app's requests unless the `dialob-session` service
+returns CORS headers for the app's origin. Activate the `cors` Spring profile
+alongside `jdbc`:
+
+```bash
+SPRING_PROFILES_ACTIVE=jdbc,cors
+```
+
+The `cors` profile loads `dev-env/dialob-session-config/application-cors.yml`,
+which whitelists the local dev origins (including `http://localhost:3001`).
+After changing this, recreate the `dialob-session` container so it picks up the
+new environment variable:
+
+```bash
+docker compose up -d --force-recreate dialob-session
+```
+
+### 3. Start the app
+
+The app serves on its own port; start it on `3001` (the origin whitelisted in
+the CORS config above):
+
+```bash
+pnpm start --port 3001 --strictPort
+```
+
+Then click **Preview** in the Composer (running on `5173`) to open the form in
+the fill app.
+
+---
+
 ## Building and deploying to demo.dialob.io
 
 ```bash


### PR DESCRIPTION
## Add `format()` string function to DEL

### Summary

Adds a `format()` function to the Dialob Expression Language so strings can be concatenated/interpolated in expression variables, e.g.:

`format('Hello {firstName}, you owe {total:#,##0.00}')`

It takes a single string-literal template using the **same `{itemId}` / `{itemId:format}` syntax as item labels**, and reuses the existing label interpolation logic so placeholder behavior (value-set labels, `:key`, `:uppercase`, `:lowercase`, number/date patterns) is identical.

### Changes

- `ParserUtil` / `ProgramBuilder`: recognize `format` and resolve it to a `STRING` type.
- `DDRLOperatorFactory`: handle `format` calls and validate the argument is a single string constant.
- `LocalizedLabelOperator`: added `createFormatExpression(...)` that runs the template through the existing label logic.
- New error codes `FORMAT_ARGUMENT_MUST_BE_CONSTANT` and `UNKNOWN_FORMAT_ITEM` (+ `FormatExpressionException`); invalid templates fail as recoverable validation errors.
- Updated DEL docs.

### Backward compatibility

`format()` is purely additive and reuses the existing label code, so existing forms compile and open exactly as before.

### Tests

- Using `format()` in an expression variable inside a form.
- Argument validation (non-constant / non-string / wrong arg count).
- Placeholder expansion, empty content, and `UNKNOWN_FORMAT_ITEM` handling.


### Examples

The following variables produce results seen in the fill session below:
| Variable | Expression |
|----------|------------|
| sum | number1 + number2 |
| greeting | format('Hello {firstName}') |
| owes | format('{firstName} owes {total}') |
| plain | format('just text') |
| upper | format('{firstName:uppercase}') |
| lower | format('{firstName:lowercase}') |
| totalFmt | format('{total:#,##0}') |
| priceFmt | format('{price:#,##0.00}') |
| choiceLabel | format('{choice1}') |
| choiceKey | format('{choice1:key}') |
| multiList | format('{multi1}') |
| sumText | format('Sum {sum}') |

<img width="1444" height="609" alt="Screenshot 2026-06-20 at 16 34 36" src="https://github.com/user-attachments/assets/89d95db8-bc67-43c2-bafd-20b1510a4425" />
<img width="1449" height="549" alt="Screenshot 2026-06-20 at 16 35 01" src="https://github.com/user-attachments/assets/63099c9b-2f41-4cf7-ab0d-33bcdc4fa7d5" />
