### PR TITLE
Improving choice and variable list UX

### DIFF
--- a/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
@@ -26,14 +26,15 @@ export interface ChoiceItemProps {
   index: number,
   valueSetId?: string,
   isGlobal?: boolean,
+  sortableId: string,
+  style?: React.CSSProperties,
+  handleProps?: SortableHandleProps,
   onRuleEdit: (index: number, rule: string) => void,
   onTextEdit: (index: number, label: LocalizedString) => void,
   onDelete: (index: number) => void,
   onUpdateId: (index: number, id: string) => void,
   onInsertBelow: (index: number) => void,
   setNodeRef?: (node: HTMLElement | null) => void,
-  style?: React.CSSProperties,
-  handleProps?: SortableHandleProps,
 }
 
 type ExpandedField = 'id' | 'rule' | string | null;
@@ -164,8 +165,8 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
 
   const expandedBg =
     expandedField === 'id' ? alpha(theme.palette.warning.main, 0.06) :
-    expandedField === 'rule' ? alpha(theme.palette.primary.main, 0.06) :
-    undefined;
+      expandedField === 'rule' ? alpha(theme.palette.primary.main, 0.06) :
+        undefined;
 
   const colSpan = isGlobal ? 2 + languageNo : 3 + languageNo;
 

--- a/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { Box, IconButton, Table, TableBody, TableCell, TableRow, TextField, Typography, alpha, useTheme } from '@mui/material';
-import { ArrowDownward, ArrowUpward, Close, Edit } from "@mui/icons-material";
+import { Box, IconButton, TableCell, TableRow, TextField, Typography, alpha, useTheme, Tooltip } from '@mui/material';
+import { Close, Edit, PostAdd } from "@mui/icons-material";
+import { FormattedMessage } from "react-intl";
 import { useComposer } from "../dialob";
 import ChoiceDeleteDialog from "../dialogs/ChoiceDeleteDialog";
 import { useErrorColor } from "../utils/ErrorUtils";
@@ -16,6 +17,8 @@ import AITranslationIndicator from "./translations/AITranslationIndicator";
 import TranslateButton from "./translations/TranslateButton";
 import { useAITranslation } from "./translations";
 import { buildValueSetEntryId } from "../utils/TranslationUtils";
+import { DragHandle, DragHandleProps } from "./DragHandle";
+import { SortableHandleProps } from "./useSortableRow";
 
 
 export interface ChoiceItemProps {
@@ -23,11 +26,14 @@ export interface ChoiceItemProps {
   index: number,
   valueSetId?: string,
   isGlobal?: boolean,
-  onRuleEdit: (entry: ValueSetEntry, rule: string) => void,
-  onTextEdit: (entry: ValueSetEntry, label: LocalizedString) => void,
-  onDelete: (entry: ValueSetEntry) => void,
-  onUpdateId: (entry: ValueSetEntry, id: string) => void,
-  onMove?: (entry: ValueSetEntry, direction: 'up' | 'down') => void
+  onRuleEdit: (index: number, rule: string) => void,
+  onTextEdit: (index: number, label: LocalizedString) => void,
+  onDelete: (index: number) => void,
+  onUpdateId: (index: number, id: string) => void,
+  onInsertBelow: (index: number) => void,
+  setNodeRef?: (node: HTMLElement | null) => void,
+  style?: React.CSSProperties,
+  handleProps?: SortableHandleProps,
 }
 
 type ExpandedField = 'id' | 'rule' | string | null;
@@ -38,10 +44,13 @@ const truncate = (value: string | undefined, maxLen = 28) => {
 };
 
 const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
-  const { entry, index, valueSetId, isGlobal, onRuleEdit, onTextEdit, onDelete, onUpdateId, onMove } = props;
+  const {
+    entry, index, valueSetId, isGlobal, onRuleEdit, onTextEdit, onDelete, onUpdateId, onInsertBelow,
+    setNodeRef, style, handleProps,
+  } = props;
   const { form } = useComposer();
   const { editor } = useEditor();
-  const { savingState, moveValueSetEntry, applyTranslations } = useSave();
+  const { applyTranslations } = useSave();
   const { translateEntries, config } = useBackend();
   const theme = useTheme();
   const formLanguages = form.metadata.languages;
@@ -55,7 +64,6 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
   const [localizedString, setLocalizedString] = React.useState<LocalizedString>(entry.label || {});
   const [localRule, setLocalRule] = React.useState(entry.when ?? '');
   const [translatingLanguage, setTranslatingLanguage] = React.useState<string | null>(null);
-  const length = savingState.valueSets?.find(v => v.id === valueSetId)?.entries?.length || 0;
 
   const getEntryId = (): string => {
     return buildValueSetEntryId(valueSetId!, index, entry.id);
@@ -82,7 +90,7 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
   const handleUpdate = (value: string, language: string) => {
     const updated = { ...localizedString, [language]: value };
     setLocalizedString(updated);
-    onTextEdit(entry, updated);
+    onTextEdit(index, updated);
     if (isAITranslated(language)) {
       removeFlag(language);
     }
@@ -92,7 +100,7 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
     const updated = { ...localizedString };
     delete updated[language];
     setLocalizedString(updated);
-    onTextEdit(entry, updated);
+    onTextEdit(index, updated);
     if (isAITranslated(language)) {
       removeFlag(language);
     }
@@ -101,20 +109,12 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
   const handleChangeId = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newId = e.target.value;
     setLocalId(newId);
-    onUpdateId(entry, newId);
+    onUpdateId(index, newId);
   };
 
   const handleUpdateRule = (value: string) => {
     setLocalRule(value);
-    onRuleEdit(entry, value);
-  };
-
-  const handleMove = (direction: 'up' | 'down') => {
-    if (valueSetId) {
-      const newIndex = direction === 'up' ? index - 1 : index + 1;
-      moveValueSetEntry(valueSetId, index, newIndex);
-      onMove?.(entry, direction);
-    }
+    onRuleEdit(index, value);
   };
 
   const handleTranslate = async (targetLanguage: string) => {
@@ -171,113 +171,116 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
 
   return (
     <>
-      <ChoiceDeleteDialog open={open} itemId={entry.id} onClick={() => onDelete(entry)} onClose={() => setOpen(false)} />
-      <Table>
-        <TableBody>
-          <TableRow sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
-            <TableCell align='center' width='15%'>
-              <IconButton sx={{ p: 0.5 }} onClick={() => setOpen(true)}><Close color='error' /></IconButton>
-              <IconButton sx={{ p: 0.5 }} onClick={() => handleMove('up')} disabled={index === 0}>
-                <ArrowUpward />
+      <ChoiceDeleteDialog open={open} itemId={entry.id} onClick={() => onDelete(index)} onClose={() => setOpen(false)} />
+      <TableRow
+        ref={setNodeRef}
+        style={style}
+        data-choice-item-row
+        sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}
+      >
+        <TableCell align='center' width='15%'>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <IconButton sx={{ p: 0.5 }} onClick={() => setOpen(true)}><Close color='error' /></IconButton>
+            <Tooltip title={<FormattedMessage id='menus.insert.below' />}>
+              <IconButton sx={{ p: 0.5 }} onClick={() => onInsertBelow(index)}>
+                <PostAdd color='success' />
               </IconButton>
-              <IconButton sx={{ p: 0.5 }} onClick={() => handleMove('down')} disabled={index === length - 1}>
-                <ArrowDownward />
-              </IconButton>
-            </TableCell>
+            </Tooltip>
+            <DragHandle {...handleProps as DragHandleProps} />
+          </Box>
+        </TableCell>
 
-            <TableCell width={isGlobal ? '20%' : '15%'} sx={{ p: 0.5 }}>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localId)}</Typography>
-                <IconButton size='small' sx={editBtnSx(expandedField === 'id', theme.palette.warning.main)} onClick={() => toggleField('id')}>
-                  <Edit fontSize='small' color={expandedField === 'id' ? 'warning' : 'inherit'} />
+        <TableCell width={isGlobal ? '20%' : '15%'} sx={{ p: 0.5 }}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localId)}</Typography>
+            <IconButton size='small' sx={editBtnSx(expandedField === 'id', theme.palette.warning.main)} onClick={() => toggleField('id')}>
+              <Edit fontSize='small' color={expandedField === 'id' ? 'warning' : 'inherit'} />
+            </IconButton>
+          </Box>
+        </TableCell>
+
+        {!isGlobal && (
+          <TableCell width='15%' sx={{ p: 0.5 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <Typography variant='body2' noWrap sx={{ flex: 1, color: entry.when ? 'text.primary' : 'text.disabled' }}>
+                {truncate(entry.when)}
+              </Typography>
+              <IconButton size='small' sx={editBtnSx(expandedField === 'rule', theme.palette.primary.main)} onClick={() => toggleField('rule')}>
+                <Edit fontSize='small' color={expandedField === 'rule' ? 'primary' : 'inherit'} />
+              </IconButton>
+            </Box>
+          </TableCell>
+        )}
+
+        {formLanguages?.map(lang => {
+          const hasValue = localizedString && localizedString[lang] !== undefined;
+          const sourceLanguage = editor.activeFormLanguage;
+          const hasSourceValue = localizedString && localizedString[sourceLanguage];
+          const canTranslate = !hasValue && hasSourceValue && lang !== sourceLanguage && config.translationServiceUrl;
+          const isTranslating = translatingLanguage === lang;
+          const aiMetadata = isAITranslated(lang) ? getAITranslationMetadata(lang) : null;
+
+          return (
+            <TableCell key={lang} width={formLanguages ? `${(isGlobal ? 65 : 55) / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localizedString?.[lang])}</Typography>
+                <IconButton size='small' sx={editBtnSx(expandedField === lang, theme.palette.action.active)} onClick={() => toggleField(lang)}>
+                  <Edit fontSize='small' color='inherit' />
                 </IconButton>
+                {canTranslate && (
+                  <TranslateButton
+                    sourceLanguage={sourceLanguage}
+                    targetLanguage={lang}
+                    isTranslating={isTranslating}
+                    onClick={() => handleTranslate(lang)}
+                  />
+                )}
+                {aiMetadata && (
+                  <AITranslationIndicator
+                    metadata={aiMetadata}
+                    onClick={() => removeFlag(lang)}
+                  />
+                )}
               </Box>
             </TableCell>
+          );
+        })}
+      </TableRow>
 
-            {!isGlobal && (
-              <TableCell width='15%' sx={{ p: 0.5 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <Typography variant='body2' noWrap sx={{ flex: 1, color: entry.when ? 'text.primary' : 'text.disabled' }}>
-                    {truncate(entry.when)}
-                  </Typography>
-                  <IconButton size='small' sx={editBtnSx(expandedField === 'rule', theme.palette.primary.main)} onClick={() => toggleField('rule')}>
-                    <Edit fontSize='small' color={expandedField === 'rule' ? 'primary' : 'inherit'} />
-                  </IconButton>
-                </Box>
-              </TableCell>
+      {expandedField && (
+        <TableRow>
+          <TableCell colSpan={colSpan} sx={{ p: 1, backgroundColor: expandedBg }}>
+            {expandedField === 'id' && (
+              <TextField
+                value={localId}
+                onChange={handleChangeId}
+                variant='standard'
+                fullWidth
+                InputProps={{ disableUnderline: true }}
+                autoFocus
+              />
             )}
-
-            {formLanguages?.map(lang => {
-              const hasValue = localizedString && localizedString[lang] !== undefined;
-              const sourceLanguage = editor.activeFormLanguage;
-              const hasSourceValue = localizedString && localizedString[sourceLanguage];
-              const canTranslate = !hasValue && hasSourceValue && lang !== sourceLanguage && config.translationServiceUrl;
-              const isTranslating = translatingLanguage === lang;
-              const aiMetadata = isAITranslated(lang) ? getAITranslationMetadata(lang) : null;
-
-              return (
-                <TableCell key={lang} width={formLanguages ? `${(isGlobal ? 65 : 55) / formLanguages.length}%` : 0} sx={{ p: 0.5 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    <Typography variant='body2' noWrap sx={{ flex: 1 }}>{truncate(localizedString?.[lang])}</Typography>
-                    <IconButton size='small' sx={editBtnSx(expandedField === lang, theme.palette.action.active)} onClick={() => toggleField(lang)}>
-                      <Edit fontSize='small' color='inherit' />
-                    </IconButton>
-                    {canTranslate && (
-                      <TranslateButton
-                        sourceLanguage={sourceLanguage}
-                        targetLanguage={lang}
-                        isTranslating={isTranslating}
-                        onClick={() => handleTranslate(lang)}
-                      />
-                    )}
-                    {aiMetadata && (
-                      <AITranslationIndicator
-                        metadata={aiMetadata}
-                        onClick={() => removeFlag(lang)}
-                      />
-                    )}
-                  </Box>
-                </TableCell>
-              );
-            })}
-          </TableRow>
-
-          {expandedField && (
-            <TableRow>
-              <TableCell colSpan={colSpan} sx={{ p: 1, backgroundColor: expandedBg }}>
-                {expandedField === 'id' && (
-                  <TextField
-                    value={localId}
-                    onChange={handleChangeId}
-                    variant='standard'
-                    fullWidth
-                    InputProps={{ disableUnderline: true }}
-                    autoFocus
-                  />
-                )}
-                {expandedField === 'rule' && (
-                  <CodeEditorWithClear value={localRule || undefined} onClear={() => handleUpdateRule('')}>
-                    <CodeMirror value={localRule} onChange={handleUpdateRule} />
-                  </CodeEditorWithClear>
-                )}
-                {formLanguages?.includes(expandedField) && (
-                  <TextEditorWithClear
-                    value={localizedString?.[expandedField]}
-                    onChange={(value) => handleUpdate(value, expandedField)}
-                    onClear={localizedString?.[expandedField] !== undefined ? () => handleClearLanguage(expandedField) : undefined}
-                    variant='standard'
-                    fullWidth
-                    multiline
-                    InputProps={{ disableUnderline: true }}
-                    autoFocus
-                    sx={{ pt: 0.5 }}
-                  />
-                )}
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
+            {expandedField === 'rule' && (
+              <CodeEditorWithClear value={localRule || undefined} onClear={() => handleUpdateRule('')}>
+                <CodeMirror value={localRule} onChange={handleUpdateRule} />
+              </CodeEditorWithClear>
+            )}
+            {formLanguages?.includes(expandedField) && (
+              <TextEditorWithClear
+                value={localizedString?.[expandedField]}
+                onChange={(value) => handleUpdate(value, expandedField)}
+                onClear={localizedString?.[expandedField] !== undefined ? () => handleClearLanguage(expandedField) : undefined}
+                variant='standard'
+                fullWidth
+                multiline
+                InputProps={{ disableUnderline: true }}
+                autoFocus
+                sx={{ pt: 0.5 }}
+              />
+            )}
+          </TableCell>
+        </TableRow>
+      )}
     </>
   );
 };

--- a/frontend/dialob-composer-material/src/components/ChoiceList.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceList.tsx
@@ -1,93 +1,147 @@
 import React from "react";
-import { TableBody, TableCell, TableRow } from "@mui/material";
-import { useComposer } from "../dialob";
+import { TableBody } from "@mui/material";
 import ChoiceItem from "./ChoiceItem";
 import { LocalizedString, ValueSet, ValueSetEntry } from "../types";
 import { useSave } from "../dialogs/contexts/saving/useSave";
+import { SortableFlatList } from "./SortableFlatList";
+import { useSortableRow } from "./useSortableRow";
+import { createDefaultValueSetEntry } from "../utils/ValueSetUtils";
+import { arrayMove } from "@dnd-kit/sortable";
+import { scrollToChoiceItem } from "../utils/ScrollUtils";
 
+
+const SortableChoiceItem: React.FC<{
+  entry: ValueSetEntry;
+  index: number;
+  sortableId: string;
+  valueSetId: string;
+  isGlobal?: boolean;
+  onRuleEdit: (index: number, rule: string) => void;
+  onTextEdit: (index: number, label: LocalizedString) => void;
+  onDelete: (index: number) => void;
+  onUpdateId: (index: number, id: string) => void;
+  onInsertBelow: (index: number) => void;
+}> = (props) => {
+  const { sortableId, ...itemProps } = props;
+  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
+
+  return (
+    <ChoiceItem
+      {...itemProps}
+      setNodeRef={setNodeRef}
+      style={style}
+      handleProps={handleProps}
+    />
+  );
+};
 
 const ChoiceList: React.FC<{
   valueSet?: ValueSet,
   updateValueSet?: (value: React.SetStateAction<ValueSet | undefined>) => void,
   isGlobal?: boolean
 }> = ({ valueSet, updateValueSet, isGlobal }) => {
-  const { form } = useComposer();
-  const { deleteValueSetEntry, updateValueSetEntry } = useSave();
-  const languageNo = form.metadata.languages?.length || 0;
+  const { deleteValueSetEntry, updateValueSetEntry, addValueSetEntry, moveValueSetEntry } = useSave();
+  const entries = valueSet?.entries ?? [];
+  const itemIds = entries.map((_, index) => `${valueSet?.id}-${index}`);
 
-  const updateValueSetEntryId = (entry: ValueSetEntry, id: string) => {
-    if (valueSet && valueSet.entries) {
-      const newEntry = { ...entry, id };
-      const idx = valueSet.entries.findIndex(e => e.id === entry.id);
-      updateValueSetEntry(valueSet.id, idx, newEntry);
-      updateValueSet?.({ ...valueSet, entries: valueSet.entries.map(e => e.id === entry.id ? newEntry : e) });
+  const updateValueSetEntryId = (index: number, id: string) => {
+    if (valueSet?.entries?.[index]) {
+      const newEntry = { ...valueSet.entries[index], id };
+      updateValueSetEntry(valueSet.id, index, newEntry);
+      updateValueSet?.({
+        ...valueSet,
+        entries: valueSet.entries.map((e, i) => i === index ? newEntry : e),
+      });
     }
   }
 
-  const updateValueSetEntryLabel = (entry: ValueSetEntry, label: LocalizedString) => {
-    if (valueSet && valueSet.entries) {
-      const newEntry = { ...entry, label };
-      const idx = valueSet.entries.findIndex(e => e.id === entry.id);
-      updateValueSetEntry(valueSet.id, idx, newEntry);
-      updateValueSet?.({ ...valueSet, entries: valueSet.entries.map(e => e.id === entry.id ? newEntry : e) });
+  const updateValueSetEntryLabel = (index: number, label: LocalizedString) => {
+    if (valueSet?.entries?.[index]) {
+      const newEntry = { ...valueSet.entries[index], label };
+      updateValueSetEntry(valueSet.id, index, newEntry);
+      updateValueSet?.({
+        ...valueSet,
+        entries: valueSet.entries.map((e, i) => i === index ? newEntry : e),
+      });
     }
   }
 
-  const updateValueSetEntryRule = (entry: ValueSetEntry, rule: string) => {
-    if (valueSet && valueSet.entries) {
-      const newEntry: ValueSetEntry = { ...entry, when: rule };
+  const updateValueSetEntryRule = (index: number, rule: string) => {
+    if (valueSet?.entries?.[index]) {
+      const newEntry: ValueSetEntry = { ...valueSet.entries[index], when: rule };
       if (rule === '') {
         delete newEntry.when;
       }
-      const idx = valueSet.entries.findIndex(e => e.id === entry.id);
-      updateValueSetEntry(valueSet.id, idx, newEntry);
-      updateValueSet?.({ ...valueSet, entries: valueSet.entries.map(e => e.id === entry.id ? newEntry : e) });
+      updateValueSetEntry(valueSet.id, index, newEntry);
+      updateValueSet?.({
+        ...valueSet,
+        entries: valueSet.entries.map((e, i) => i === index ? newEntry : e),
+      });
     }
   }
 
-  const onDeleteValueSetEntry = (entry: ValueSetEntry) => {
-    if (valueSet && valueSet.entries) {
-      const idx = valueSet.entries.findIndex(e => e.id === entry.id);
-      deleteValueSetEntry(valueSet.id, idx);
-      updateValueSet?.({ ...valueSet, entries: valueSet.entries.filter(e => e.id !== entry.id) });
+  const onDeleteValueSetEntry = (index: number) => {
+    if (valueSet?.entries?.[index]) {
+      deleteValueSetEntry(valueSet.id, index);
+      updateValueSet?.({
+        ...valueSet,
+        entries: valueSet.entries.filter((_, i) => i !== index),
+      });
     }
   }
 
-  const moveValueSetEntry = (entry: ValueSetEntry, direction: 'up' | 'down') => {
-    if (valueSet && valueSet.entries) {
-      const idx = valueSet.entries.findIndex(e => e.id === entry.id);
-      if (idx < 0 || (direction === 'up' && idx === 0) || (direction === 'down' && idx === valueSet.entries.length - 1)) {
-        return;
-      }
-      const newEntries = [...valueSet.entries];
-      const swapIndex = direction === 'up' ? idx - 1 : idx + 1;
-      newEntries[idx] = valueSet.entries[swapIndex];
-      newEntries[swapIndex] = entry;
-      updateValueSet?.({ ...valueSet, entries: newEntries });
+  const handleInsertBelow = (index: number) => {
+    if (!valueSet) {
+      return;
     }
+    const newEntry = createDefaultValueSetEntry(valueSet.entries);
+    addValueSetEntry(valueSet.id, newEntry, index);
+    const newEntries = valueSet.entries ? [...valueSet.entries] : [];
+    newEntries.splice(index + 1, 0, newEntry);
+    updateValueSet?.({ ...valueSet, entries: newEntries });
+    scrollToChoiceItem(index + 1);
+  };
+
+  const handleReorder = (activeId: string, overId: string) => {
+    if (!valueSet?.entries) {
+      return;
+    }
+    const fromIndex = itemIds.indexOf(activeId);
+    const toIndex = itemIds.indexOf(overId);
+    if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) {
+      return;
+    }
+    moveValueSetEntry(valueSet.id, fromIndex, toIndex);
+    updateValueSet?.({
+      ...valueSet,
+      entries: arrayMove([...valueSet.entries], fromIndex, toIndex),
+    });
+  };
+
+  if (!valueSet || entries.length === 0) {
+    return <TableBody />;
   }
 
   return (
-    <TableBody>
-      <TableRow>
-        <TableCell colSpan={isGlobal ? 2 + languageNo : 3 + languageNo}>
-          {valueSet?.entries && valueSet.entries?.length > 0 && valueSet.entries.map((entry, index) => (
-            <ChoiceItem 
-              key={`${valueSet.id}-${index}`}
-              entry={entry}
-              index={index}
-              valueSetId={valueSet.id}
-              isGlobal={isGlobal}
-              onRuleEdit={updateValueSetEntryRule}
-              onTextEdit={updateValueSetEntryLabel}
-              onDelete={onDeleteValueSetEntry}
-              onUpdateId={updateValueSetEntryId}
-              onMove={moveValueSetEntry}
-            />
-          ))}
-        </TableCell>
-      </TableRow>
-    </TableBody>
+    <SortableFlatList itemIds={itemIds} onReorder={handleReorder}>
+      <TableBody>
+        {entries.map((entry, index) => (
+          <SortableChoiceItem
+            key={itemIds[index]}
+            sortableId={itemIds[index]}
+            entry={entry}
+            index={index}
+            valueSetId={valueSet.id}
+            isGlobal={isGlobal}
+            onRuleEdit={updateValueSetEntryRule}
+            onTextEdit={updateValueSetEntryLabel}
+            onDelete={onDeleteValueSetEntry}
+            onUpdateId={updateValueSetEntryId}
+            onInsertBelow={handleInsertBelow}
+          />
+        ))}
+      </TableBody>
+    </SortableFlatList>
   );
 };
 

--- a/frontend/dialob-composer-material/src/components/ChoiceList.tsx
+++ b/frontend/dialob-composer-material/src/components/ChoiceList.tsx
@@ -1,39 +1,13 @@
 import React from "react";
 import { TableBody } from "@mui/material";
-import ChoiceItem from "./ChoiceItem";
 import { LocalizedString, ValueSet, ValueSetEntry } from "../types";
 import { useSave } from "../dialogs/contexts/saving/useSave";
 import { SortableFlatList } from "./SortableFlatList";
-import { useSortableRow } from "./useSortableRow";
 import { createDefaultValueSetEntry } from "../utils/ValueSetUtils";
 import { arrayMove } from "@dnd-kit/sortable";
 import { scrollToChoiceItem } from "../utils/ScrollUtils";
+import { SortableChoiceItem } from "./SortableChoiceItem";
 
-
-const SortableChoiceItem: React.FC<{
-  entry: ValueSetEntry;
-  index: number;
-  sortableId: string;
-  valueSetId: string;
-  isGlobal?: boolean;
-  onRuleEdit: (index: number, rule: string) => void;
-  onTextEdit: (index: number, label: LocalizedString) => void;
-  onDelete: (index: number) => void;
-  onUpdateId: (index: number, id: string) => void;
-  onInsertBelow: (index: number) => void;
-}> = (props) => {
-  const { sortableId, ...itemProps } = props;
-  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
-
-  return (
-    <ChoiceItem
-      {...itemProps}
-      setNodeRef={setNodeRef}
-      style={style}
-      handleProps={handleProps}
-    />
-  );
-};
 
 const ChoiceList: React.FC<{
   valueSet?: ValueSet,
@@ -48,10 +22,7 @@ const ChoiceList: React.FC<{
     if (valueSet?.entries?.[index]) {
       const newEntry = { ...valueSet.entries[index], id };
       updateValueSetEntry(valueSet.id, index, newEntry);
-      updateValueSet?.({
-        ...valueSet,
-        entries: valueSet.entries.map((e, i) => i === index ? newEntry : e),
-      });
+      updateValueSet?.({ ...valueSet, entries: valueSet.entries.map((e, i) => i === index ? newEntry : e) });
     }
   }
 
@@ -59,10 +30,7 @@ const ChoiceList: React.FC<{
     if (valueSet?.entries?.[index]) {
       const newEntry = { ...valueSet.entries[index], label };
       updateValueSetEntry(valueSet.id, index, newEntry);
-      updateValueSet?.({
-        ...valueSet,
-        entries: valueSet.entries.map((e, i) => i === index ? newEntry : e),
-      });
+      updateValueSet?.({ ...valueSet, entries: valueSet.entries.map((e, i) => i === index ? newEntry : e) });
     }
   }
 
@@ -73,20 +41,14 @@ const ChoiceList: React.FC<{
         delete newEntry.when;
       }
       updateValueSetEntry(valueSet.id, index, newEntry);
-      updateValueSet?.({
-        ...valueSet,
-        entries: valueSet.entries.map((e, i) => i === index ? newEntry : e),
-      });
+      updateValueSet?.({ ...valueSet, entries: valueSet.entries.map((e, i) => i === index ? newEntry : e) });
     }
   }
 
   const onDeleteValueSetEntry = (index: number) => {
     if (valueSet?.entries?.[index]) {
       deleteValueSetEntry(valueSet.id, index);
-      updateValueSet?.({
-        ...valueSet,
-        entries: valueSet.entries.filter((_, i) => i !== index),
-      });
+      updateValueSet?.({ ...valueSet, entries: valueSet.entries.filter((_, i) => i !== index) });
     }
   }
 
@@ -112,10 +74,7 @@ const ChoiceList: React.FC<{
       return;
     }
     moveValueSetEntry(valueSet.id, fromIndex, toIndex);
-    updateValueSet?.({
-      ...valueSet,
-      entries: arrayMove([...valueSet.entries], fromIndex, toIndex),
-    });
+    updateValueSet?.({ ...valueSet, entries: arrayMove([...valueSet.entries], fromIndex, toIndex) });
   };
 
   if (!valueSet || entries.length === 0) {

--- a/frontend/dialob-composer-material/src/components/DragHandle.tsx
+++ b/frontend/dialob-composer-material/src/components/DragHandle.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { IconButton, IconButtonProps, styled } from '@mui/material';
+import { DragIndicator } from '@mui/icons-material';
+
+const StyledDragHandle = styled(IconButton)({
+  padding: 4,
+  cursor: 'grab',
+  '&:active': {
+    cursor: 'grabbing',
+  },
+});
+
+export type DragHandleProps = IconButtonProps;
+
+export const DragHandle = React.forwardRef<HTMLButtonElement, DragHandleProps>(
+  (props, ref) => (
+    <StyledDragHandle ref={ref} size="small" {...props}>
+      <DragIndicator fontSize="small" />
+    </StyledDragHandle>
+  )
+);
+
+DragHandle.displayName = 'DragHandle';

--- a/frontend/dialob-composer-material/src/components/SortableChoiceItem.tsx
+++ b/frontend/dialob-composer-material/src/components/SortableChoiceItem.tsx
@@ -1,0 +1,17 @@
+import ChoiceItem, { ChoiceItemProps } from "./ChoiceItem";
+import { useSortableRow } from "./useSortableRow";
+
+export const SortableChoiceItem: React.FC<ChoiceItemProps> = (props) => {
+  const { sortableId, ...itemProps } = props;
+  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
+
+  return (
+    <ChoiceItem
+      {...itemProps}
+      sortableId={sortableId}
+      setNodeRef={setNodeRef}
+      style={style}
+      handleProps={handleProps}
+    />
+  );
+};

--- a/frontend/dialob-composer-material/src/components/SortableFlatList.tsx
+++ b/frontend/dialob-composer-material/src/components/SortableFlatList.tsx
@@ -16,11 +16,7 @@ interface SortableFlatListProps {
 }
 
 export const SortableFlatList: React.FC<SortableFlatListProps> = ({ itemIds, onReorder, children }) => {
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { distance: 5 },
-    })
-  );
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
     if (over && active.id !== over.id) {

--- a/frontend/dialob-composer-material/src/components/SortableFlatList.tsx
+++ b/frontend/dialob-composer-material/src/components/SortableFlatList.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+
+interface SortableFlatListProps {
+  itemIds: string[];
+  onReorder: (activeId: string, overId: string) => void;
+  children: React.ReactNode;
+}
+
+export const SortableFlatList: React.FC<SortableFlatListProps> = ({ itemIds, onReorder, children }) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    })
+  );
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (over && active.id !== over.id) {
+      onReorder(String(active.id), String(over.id));
+    }
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+        {children}
+      </SortableContext>
+    </DndContext>
+  );
+};

--- a/frontend/dialob-composer-material/src/components/editors/ChoiceEditor.tsx
+++ b/frontend/dialob-composer-material/src/components/editors/ChoiceEditor.tsx
@@ -19,6 +19,7 @@ import { getErrorSeverity } from '../../utils/ErrorUtils';
 import { scrollToChoiceItem } from '../../utils/ScrollUtils';
 import { ValueSet } from '../../types';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
+import { createDefaultValueSetEntry } from '../../utils/ValueSetUtils';
 import TranslateChoicesConfirmDialog from '../translations/TranslateChoicesConfirmDialog';
 import TranslationProgressDialog from '../translations/TranslationProgressDialog';
 import { useHasTranslatableContent, useBulkTranslateValueSet } from '../translations';
@@ -40,7 +41,7 @@ const ChoiceEditor: React.FC = () => {
   const [uploadDialogOpen, setUploadDialogOpen] = React.useState(false);
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
   const [translateDialogOpen, setTranslateDialogOpen] = React.useState(false);
-  
+
   const sourceLanguage = editor.activeFormLanguage;
   const targetLanguages = formLanguages?.filter(lang => lang !== sourceLanguage) || [];
   const hasTranslatableContent = useHasTranslatableContent(currentValueSet, sourceLanguage, targetLanguages);
@@ -64,21 +65,9 @@ const ChoiceEditor: React.FC = () => {
 
   const handleAddValueSetEntry = () => {
     if (currentValueSet) {
-      if (!currentValueSet.entries) {
-        const newEntry = {
-          id: 'choice1',
-          label: {}
-        }
-        addValueSetEntry(currentValueSet.id, newEntry);
-        scrollToChoiceItem();
-      } else {
-        const newEntry = {
-          id: 'choice' + (currentValueSet.entries?.length + 1),
-          label: {},
-        };
-        addValueSetEntry(currentValueSet.id, newEntry);
-        scrollToChoiceItem();
-      }
+      const newEntry = createDefaultValueSetEntry(currentValueSet.entries);
+      addValueSetEntry(currentValueSet.id, newEntry);
+      scrollToChoiceItem();
     }
   }
 
@@ -139,7 +128,7 @@ const ChoiceEditor: React.FC = () => {
         type={dialogType}
         onClick={dialogType === 'global' ? convertToGlobalList : convertToLocalList}
         onClose={() => setDialogType(undefined)} />
-      
+
       <TranslateChoicesConfirmDialog
         open={translateDialogOpen}
         onConfirm={handleTranslateAllChoices}

--- a/frontend/dialob-composer-material/src/components/useSortableRow.ts
+++ b/frontend/dialob-composer-material/src/components/useSortableRow.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+import { DraggableAttributes } from '@dnd-kit/core';
+import { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+export type SortableHandleProps = DraggableAttributes & SyntheticListenerMap;
+
+export const useSortableRow = (id: string) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return {
+    setNodeRef,
+    style,
+    handleProps: {
+      ...attributes,
+      ...listeners,
+    } as SortableHandleProps,
+    isDragging,
+  };
+};

--- a/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
@@ -1,35 +1,27 @@
 import React from 'react';
-import { Box, IconButton, TableCell, TableRow, Typography, alpha, useTheme } from '@mui/material';
+import { Box, IconButton, TableCell, TableRow, Tooltip, Typography, alpha, useTheme } from '@mui/material';
+import { Edit, PostAdd } from '@mui/icons-material';
+import { FormattedMessage } from 'react-intl';
 import { ContextVariable } from '../../types';
 import { useEditor } from '../../editor';
 import { useErrorColorSx } from '../../utils/ErrorUtils';
 import {
   ContextTypeMenu, DefaultValueField, DeleteButton, DescriptionField,
-  NameField, PublishedSwitch, UsersField, VariableProps
+  NameField, PublishedSwitch, UsersField, SortableVariableRowProps
 } from './VariableComponents';
-import { ArrowDownward, ArrowUpward, Edit } from '@mui/icons-material';
-import { isContextVariable } from '../../utils/ItemUtils';
-import { useSave } from '../../dialogs/contexts/saving/useSave';
+import { DragHandle, DragHandleProps } from '../DragHandle';
 
 type ExpandedField = 'name' | 'defaultValue' | 'description' | null;
 
-const ContextVariableRow: React.FC<VariableProps> = React.memo(function ContextVariableRow({ index, item, onClose }) {
+const ContextVariableRow: React.FC<SortableVariableRowProps> = React.memo(function ContextVariableRow({
+  index, item, onClose, onInsertBelow, setNodeRef, style, handleProps,
+}) {
   const { editor } = useEditor();
-  const { savingState, moveVariable } = useSave();
   const theme = useTheme();
   const variable = item as ContextVariable;
   const errorColorSx = useErrorColorSx(editor.errors, variable.name);
   const backgroundColor = errorColorSx ? errorColorSx : theme.palette.background.paper;
-  const contextVariables = savingState.variables?.filter(v => isContextVariable(v));
   const [expandedField, setExpandedField] = React.useState<ExpandedField>(null);
-
-  const handleMove = (direction: 'up' | 'down') => {
-    const destination = direction === 'up' ? index - 1 : index + 1;
-    const destinationVariable = contextVariables?.[destination];
-    if (destinationVariable) {
-      moveVariable(variable, destinationVariable);
-    }
-  }
 
   const toggleField = (field: ExpandedField) => {
     setExpandedField(prev => prev === field ? null : field);
@@ -51,22 +43,21 @@ const ContextVariableRow: React.FC<VariableProps> = React.memo(function ContextV
 
   return (
     <>
-      <TableRow key={variable.name} sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
+      <TableRow
+        ref={setNodeRef}
+        style={style}
+        data-variable-row
+        sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}
+      >
         <TableCell width='10%' align='center' sx={{ p: 0.5 }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <DeleteButton variable={variable} />
-            <IconButton
-              sx={{ p: 0.5 }}
-              disabled={index === 0}
-              onClick={() => handleMove('up')}>
-                <ArrowUpward />
+            <Tooltip title={<FormattedMessage id='menus.insert.below' />}>
+              <IconButton sx={{ p: 0.5 }} onClick={() => onInsertBelow(index)}>
+                <PostAdd color='success' />
               </IconButton>
-            <IconButton
-              sx={{ p: 0.5 }}
-              disabled={index === (contextVariables?.length || 0) - 1}
-              onClick={() => handleMove('down')}>
-              <ArrowDownward />
-            </IconButton>
+            </Tooltip>
+            <DragHandle {...handleProps as DragHandleProps} />
           </Box>
         </TableCell>
         <TableCell width='10%' align='center' sx={{ p: 0.5 }}>

--- a/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ContextVariableRow.tsx
@@ -7,13 +7,13 @@ import { useEditor } from '../../editor';
 import { useErrorColorSx } from '../../utils/ErrorUtils';
 import {
   ContextTypeMenu, DefaultValueField, DeleteButton, DescriptionField,
-  NameField, PublishedSwitch, UsersField, SortableVariableRowProps
+  NameField, PublishedSwitch, UsersField, VariableProps
 } from './VariableComponents';
 import { DragHandle, DragHandleProps } from '../DragHandle';
 
 type ExpandedField = 'name' | 'defaultValue' | 'description' | null;
 
-const ContextVariableRow: React.FC<SortableVariableRowProps> = React.memo(function ContextVariableRow({
+const ContextVariableRow: React.FC<VariableProps> = React.memo(function ContextVariableRow({
   index, item, onClose, onInsertBelow, setNodeRef, style, handleProps,
 }) {
   const { editor } = useEditor();

--- a/frontend/dialob-composer-material/src/components/variables/ContextVariables.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ContextVariables.tsx
@@ -3,33 +3,13 @@ import { IconButton, TableBody, TableCell, TableHead, TableRow, Typography } fro
 import { Add } from "@mui/icons-material";
 import { FormattedMessage } from "react-intl";
 import { BorderedTable } from "../TableEditorComponents";
-import ContextVariableRow from "./ContextVariableRow";
 import { isContextVariable } from "../../utils/ItemUtils";
 import { ContextVariable } from "../../types";
 import { useSave } from "../../dialogs/contexts/saving/useSave";
 import { SortableFlatList } from "../SortableFlatList";
-import { useSortableRow } from "../useSortableRow";
 import { scrollToVariableRow } from "../../utils/ScrollUtils";
+import { SortableContextVariableRow } from "./SortableContextVariableRow";
 
-const contextSortableId = (index: number) => `context-${index}`;
-
-const SortableContextVariableRow: React.FC<{
-  item: ContextVariable;
-  index: number;
-  sortableId: string;
-  onClose: () => void;
-  onInsertBelow: (index: number) => void;
-}> = ({ sortableId, ...rowProps }) => {
-  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
-  return (
-    <ContextVariableRow
-      {...rowProps}
-      setNodeRef={setNodeRef}
-      style={style}
-      handleProps={handleProps}
-    />
-  );
-};
 
 const ContextVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const { savingState, createVariable, moveVariable } = useSave();
@@ -45,7 +25,7 @@ const ContextVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => {
       );
   }, [savingState.variables]);
 
-  const itemIds = contextVariableRows.map((_, index) => contextSortableId(index));
+  const itemIds = contextVariableRows.map((_, index) => `context-${index}`);
 
   const handleAdd = () => {
     createVariable(true);

--- a/frontend/dialob-composer-material/src/components/variables/ContextVariables.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ContextVariables.tsx
@@ -7,13 +7,68 @@ import ContextVariableRow from "./ContextVariableRow";
 import { isContextVariable } from "../../utils/ItemUtils";
 import { ContextVariable } from "../../types";
 import { useSave } from "../../dialogs/contexts/saving/useSave";
+import { SortableFlatList } from "../SortableFlatList";
+import { useSortableRow } from "../useSortableRow";
+import { scrollToVariableRow } from "../../utils/ScrollUtils";
+
+const contextSortableId = (index: number) => `context-${index}`;
+
+const SortableContextVariableRow: React.FC<{
+  item: ContextVariable;
+  index: number;
+  sortableId: string;
+  onClose: () => void;
+  onInsertBelow: (index: number) => void;
+}> = ({ sortableId, ...rowProps }) => {
+  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
+  return (
+    <ContextVariableRow
+      {...rowProps}
+      setNodeRef={setNodeRef}
+      style={style}
+      handleProps={handleProps}
+    />
+  );
+};
 
 const ContextVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => {
-  const { savingState, createVariable } = useSave();
+  const { savingState, createVariable, moveVariable } = useSave();
+
+  const contextVariableRows = React.useMemo(() => {
+    if (!savingState.variables) {
+      return [];
+    }
+    return savingState.variables
+      .map((variable, absoluteIndex) => ({ variable, absoluteIndex }))
+      .filter((row): row is { variable: ContextVariable; absoluteIndex: number } =>
+        isContextVariable(row.variable)
+      );
+  }, [savingState.variables]);
+
+  const itemIds = contextVariableRows.map((_, index) => contextSortableId(index));
 
   const handleAdd = () => {
     createVariable(true);
-  }
+    scrollToVariableRow();
+  };
+
+  const handleInsertBelow = (index: number) => {
+    const row = contextVariableRows[index];
+    if (!row) {
+      return;
+    }
+    createVariable(true, row.absoluteIndex);
+    scrollToVariableRow(index + 1);
+  };
+
+  const handleReorder = (activeId: string, overId: string) => {
+    const fromFilteredIndex = itemIds.indexOf(activeId);
+    const toFilteredIndex = itemIds.indexOf(overId);
+    const row = contextVariableRows[fromFilteredIndex];
+    if (fromFilteredIndex >= 0 && toFilteredIndex >= 0 && row) {
+      moveVariable(row.variable.name, toFilteredIndex, true);
+    }
+  };
 
   return (
     <BorderedTable sx={{ tableLayout: 'fixed' }}>
@@ -42,11 +97,20 @@ const ContextVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           </TableCell>
         </TableRow>
       </TableHead>
-      <TableBody>
-        {(savingState.variables?.filter(v => isContextVariable(v)) as ContextVariable[])?.map((item, index) => (
-          <ContextVariableRow key={index} index={index} item={item} onClose={onClose} />
-        ))}
-      </TableBody>
+      <SortableFlatList itemIds={itemIds} onReorder={handleReorder}>
+        <TableBody>
+          {contextVariableRows.map(({ variable }, index) => (
+            <SortableContextVariableRow
+              key={itemIds[index]}
+              sortableId={itemIds[index]}
+              item={variable}
+              index={index}
+              onClose={onClose}
+              onInsertBelow={handleInsertBelow}
+            />
+          ))}
+        </TableBody>
+      </SortableFlatList>
     </BorderedTable>
   )
 }

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
@@ -5,13 +5,13 @@ import { FormattedMessage } from 'react-intl';
 import { Variable } from '../../types';
 import { useEditor } from '../../editor';
 import { getErrorSeverity, useErrorColorSx } from '../../utils/ErrorUtils';
-import { DeleteButton, DescriptionField, ExpressionField, NameField, PublishedSwitch, UsersField, SortableVariableRowProps } from './VariableComponents';
+import { DeleteButton, DescriptionField, ExpressionField, NameField, PublishedSwitch, UsersField, VariableProps } from './VariableComponents';
 import { ErrorMessage } from '../ErrorComponents';
 import { DragHandle, DragHandleProps } from '../DragHandle';
 
 type ExpandedField = 'name' | 'expression' | 'description' | null;
 
-const ExpressionVariableRow: React.FC<SortableVariableRowProps> = React.memo(function ExpressionVariableRow({
+const ExpressionVariableRow: React.FC<VariableProps> = React.memo(function ExpressionVariableRow({
   index, item, onClose, onInsertBelow, setNodeRef, style, handleProps,
 }) {
   const { editor } = useEditor();

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariableRow.tsx
@@ -1,34 +1,26 @@
 import React from 'react';
-import { Alert, Box, IconButton, TableCell, TableRow, Typography, alpha, useTheme } from '@mui/material';
+import { Alert, Box, IconButton, TableCell, TableRow, Tooltip, Typography, alpha, useTheme } from '@mui/material';
+import { Edit, PostAdd, Warning } from '@mui/icons-material';
+import { FormattedMessage } from 'react-intl';
 import { Variable } from '../../types';
 import { useEditor } from '../../editor';
 import { getErrorSeverity, useErrorColorSx } from '../../utils/ErrorUtils';
-import { DeleteButton, DescriptionField, ExpressionField, NameField, PublishedSwitch, UsersField, VariableProps } from './VariableComponents';
-import { ArrowDownward, ArrowUpward, Edit, Warning } from '@mui/icons-material';
+import { DeleteButton, DescriptionField, ExpressionField, NameField, PublishedSwitch, UsersField, SortableVariableRowProps } from './VariableComponents';
 import { ErrorMessage } from '../ErrorComponents';
-import { isContextVariable } from '../../utils/ItemUtils';
-import { useSave } from '../../dialogs/contexts/saving/useSave';
+import { DragHandle, DragHandleProps } from '../DragHandle';
 
 type ExpandedField = 'name' | 'expression' | 'description' | null;
 
-const ExpressionVariableRow: React.FC<VariableProps> = React.memo(function ExpressionVariableRow({ index, item, onClose }) {
+const ExpressionVariableRow: React.FC<SortableVariableRowProps> = React.memo(function ExpressionVariableRow({
+  index, item, onClose, onInsertBelow, setNodeRef, style, handleProps,
+}) {
   const { editor } = useEditor();
-  const { savingState, moveVariable } = useSave();
   const theme = useTheme();
   const variable = item as Variable;
   const errorColorSx = useErrorColorSx(editor.errors, variable.name);
   const backgroundColor = errorColorSx ? errorColorSx : theme.palette.background.paper;
   const itemErrors = editor.errors?.filter(e => e.itemId === variable.name);
   const [expandedField, setExpandedField] = React.useState<ExpandedField>(null);
-  const expressionVariables = savingState.variables?.filter(v => !isContextVariable(v));
-
-  const handleMove = (direction: 'up' | 'down') => {
-    const destination = direction === 'up' ? index - 1 : index + 1;
-    const destinationVariable = expressionVariables?.[destination];
-    if (destinationVariable) {
-      moveVariable(variable, destinationVariable);
-    }
-  }
 
   const toggleField = (field: ExpandedField) => {
     setExpandedField(prev => prev === field ? null : field);
@@ -52,22 +44,21 @@ const ExpressionVariableRow: React.FC<VariableProps> = React.memo(function Expre
 
   return (
     <>
-      <TableRow key={variable.name} sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}>
+      <TableRow
+        ref={setNodeRef}
+        style={style}
+        data-variable-row
+        sx={{ backgroundColor: alpha(backgroundColor, 0.1) }}
+      >
         <TableCell width='10%' align='center' sx={{ p: 1 }}>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <DeleteButton variable={variable} />
-            <IconButton
-              sx={{ p: 0.5 }}
-              disabled={index === 0}
-              onClick={() => handleMove('up')}>
-                <ArrowUpward />
+            <Tooltip title={<FormattedMessage id='menus.insert.below' />}>
+              <IconButton sx={{ p: 0.5 }} onClick={() => onInsertBelow(index)}>
+                <PostAdd color='success' />
               </IconButton>
-            <IconButton
-              sx={{ p: 0.5 }}
-              disabled={index === (expressionVariables?.length || 0) - 1}
-              onClick={() => handleMove('down')}>
-              <ArrowDownward />
-            </IconButton>
+            </Tooltip>
+            <DragHandle {...handleProps as DragHandleProps} />
           </Box>
         </TableCell>
         <TableCell width='10%' align='center' sx={{ p: 1 }}>

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariables.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariables.tsx
@@ -7,23 +7,71 @@ import { isContextVariable } from "../../utils/ItemUtils";
 import { Variable } from "../../types";
 import ExpressionVariableRow from "./ExpressionVariableRow";
 import { useSave } from "../../dialogs/contexts/saving/useSave";
+import { SortableFlatList } from "../SortableFlatList";
+import { useSortableRow } from "../useSortableRow";
+import { scrollToVariableRow } from "../../utils/ScrollUtils";
 
+const expressionSortableId = (index: number) => `expression-${index}`;
+
+const SortableExpressionVariableRow: React.FC<{
+  item: Variable;
+  index: number;
+  sortableId: string;
+  onClose: () => void;
+  onInsertBelow: (index: number) => void;
+}> = ({ sortableId, ...rowProps }) => {
+  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
+  return (
+    <ExpressionVariableRow
+      {...rowProps}
+      setNodeRef={setNodeRef}
+      style={style}
+      handleProps={handleProps}
+    />
+  );
+};
 
 const ExpressionVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => {
-  const { savingState, createVariable } = useSave();
+  const { savingState, createVariable, moveVariable } = useSave();
+
+  const expressionVariableRows = React.useMemo(() => {
+    if (!savingState.variables) {
+      return [];
+    }
+    const rowgroups = Object.values(savingState.items || {}).filter(item => item.type === 'rowgroup');
+    const scopedVariableIds = new Set(rowgroups.flatMap(rg => rg.items || []));
+
+    return savingState.variables
+      .map((variable, absoluteIndex) => ({ variable, absoluteIndex }))
+      .filter((row): row is { variable: Variable; absoluteIndex: number } =>
+        !isContextVariable(row.variable) && !scopedVariableIds.has(row.variable.name)
+      );
+  }, [savingState.variables, savingState.items]);
+
+  const itemIds = expressionVariableRows.map((_, index) => expressionSortableId(index));
 
   const handleAdd = () => {
     createVariable(false);
-  }
+    scrollToVariableRow();
+  };
 
-  // Filter out scoped variables (those that are in any rowgroup's items array)
-  const globalVariables = React.useMemo(() => {
-    const expressionVars = savingState.variables?.filter(v => !isContextVariable(v)) as Variable[] || [];
-    const rowgroups = Object.values(savingState.items || {}).filter(item => item.type === 'rowgroup');
-    const scopedVariableIds = new Set(rowgroups.flatMap(rg => rg.items || []));
-    
-    return expressionVars.filter(v => !scopedVariableIds.has(v.name));
-  }, [savingState.variables, savingState.items]);
+  const handleInsertBelow = (index: number) => {
+    const row = expressionVariableRows[index];
+    if (!row) {
+      return;
+    }
+    createVariable(false, row.absoluteIndex);
+    scrollToVariableRow(index + 1);
+  };
+
+  const handleReorder = (activeId: string, overId: string) => {
+    const fromFilteredIndex = itemIds.indexOf(activeId);
+    const toFilteredIndex = itemIds.indexOf(overId);
+    const row = expressionVariableRows[fromFilteredIndex];
+    if (fromFilteredIndex >= 0 && toFilteredIndex >= 0 && row) {
+      moveVariable(row.variable.name, toFilteredIndex, false);
+    }
+  };
 
   return (
     <BorderedTable sx={{ tableLayout: 'fixed' }}>
@@ -49,11 +97,20 @@ const ExpressionVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => 
           </TableCell>
         </TableRow>
       </TableHead>
-      <TableBody>
-        {globalVariables.map((item, index) => (
-          <ExpressionVariableRow key={index} index={index} item={item} onClose={onClose} />
-        ))}
-      </TableBody>
+      <SortableFlatList itemIds={itemIds} onReorder={handleReorder}>
+        <TableBody>
+          {expressionVariableRows.map(({ variable }, index) => (
+            <SortableExpressionVariableRow
+              key={itemIds[index]}
+              sortableId={itemIds[index]}
+              item={variable}
+              index={index}
+              onClose={onClose}
+              onInsertBelow={handleInsertBelow}
+            />
+          ))}
+        </TableBody>
+      </SortableFlatList>
     </BorderedTable>
   )
 }

--- a/frontend/dialob-composer-material/src/components/variables/ExpressionVariables.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/ExpressionVariables.tsx
@@ -5,31 +5,11 @@ import { FormattedMessage } from "react-intl";
 import { BorderedTable } from "../TableEditorComponents";
 import { isContextVariable } from "../../utils/ItemUtils";
 import { Variable } from "../../types";
-import ExpressionVariableRow from "./ExpressionVariableRow";
 import { useSave } from "../../dialogs/contexts/saving/useSave";
 import { SortableFlatList } from "../SortableFlatList";
-import { useSortableRow } from "../useSortableRow";
 import { scrollToVariableRow } from "../../utils/ScrollUtils";
+import { SortableExpressionVariableRow } from "./SortableExpressionVariableRow";
 
-const expressionSortableId = (index: number) => `expression-${index}`;
-
-const SortableExpressionVariableRow: React.FC<{
-  item: Variable;
-  index: number;
-  sortableId: string;
-  onClose: () => void;
-  onInsertBelow: (index: number) => void;
-}> = ({ sortableId, ...rowProps }) => {
-  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
-  return (
-    <ExpressionVariableRow
-      {...rowProps}
-      setNodeRef={setNodeRef}
-      style={style}
-      handleProps={handleProps}
-    />
-  );
-};
 
 const ExpressionVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const { savingState, createVariable, moveVariable } = useSave();
@@ -48,7 +28,7 @@ const ExpressionVariables: React.FC<{ onClose: () => void }> = ({ onClose }) => 
       );
   }, [savingState.variables, savingState.items]);
 
-  const itemIds = expressionVariableRows.map((_, index) => expressionSortableId(index));
+  const itemIds = expressionVariableRows.map((_, index) => `expression-${index}`);
 
   const handleAdd = () => {
     createVariable(false);

--- a/frontend/dialob-composer-material/src/components/variables/SortableContextVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/SortableContextVariableRow.tsx
@@ -1,0 +1,18 @@
+import { ContextVariable } from "../../types";
+import { useSortableRow } from "../useSortableRow";
+import ContextVariableRow from "./ContextVariableRow";
+import { VariableProps } from "./VariableComponents";
+
+export const SortableContextVariableRow: React.FC<VariableProps> = ({ sortableId, item, ...rowProps }) => {
+  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
+  return (
+    <ContextVariableRow
+      {...rowProps}
+      item={item as ContextVariable}
+      sortableId={sortableId}
+      setNodeRef={setNodeRef}
+      style={style}
+      handleProps={handleProps}
+    />
+  );
+};

--- a/frontend/dialob-composer-material/src/components/variables/SortableExpressionVariableRow.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/SortableExpressionVariableRow.tsx
@@ -1,0 +1,18 @@
+import { Variable } from "../../types";
+import { useSortableRow } from "../useSortableRow";
+import ExpressionVariableRow from "./ExpressionVariableRow";
+import { VariableProps } from "./VariableComponents";
+
+export const SortableExpressionVariableRow: React.FC<VariableProps> = ({ sortableId, item, ...rowProps }) => {
+  const { setNodeRef, style, handleProps } = useSortableRow(sortableId);
+  return (
+    <ExpressionVariableRow
+      {...rowProps}
+      item={item as Variable}
+      sortableId={sortableId}
+      setNodeRef={setNodeRef}
+      style={style}
+      handleProps={handleProps}
+    />
+  );
+};

--- a/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
@@ -10,6 +10,7 @@ import CodeMirror from '../code/CodeMirror';
 import { validateId } from '../../utils/ValidateUtils';
 import { CodeEditorWithClear } from '../code/CodeEditorWithClear';
 import { ContextVariable, ContextVariableType, DialobItem, Variable } from '../../types';
+import { SortableHandleProps } from '../useSortableRow';
 import { useComposer } from '../../dialob';
 import { useSave } from '../../dialogs/contexts/saving/useSave';
 import { TextEditorWithClear } from '../editors/TextEditorWithClear';
@@ -27,6 +28,13 @@ export interface VariableProps {
   index: number;
   item: Variable | ContextVariable;
   onClose: () => void;
+}
+
+export interface SortableVariableRowProps extends VariableProps {
+  onInsertBelow: (index: number) => void;
+  setNodeRef?: (node: HTMLElement | null) => void;
+  style?: React.CSSProperties;
+  handleProps?: SortableHandleProps;
 }
 
 export const DeleteButton: React.FC<{ variable: ContextVariable | Variable }> = ({ variable }) => {

--- a/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
+++ b/frontend/dialob-composer-material/src/components/variables/VariableComponents.tsx
@@ -27,14 +27,12 @@ const VARIABLE_TYPES: ContextVariableType[] = [
 export interface VariableProps {
   index: number;
   item: Variable | ContextVariable;
-  onClose: () => void;
-}
-
-export interface SortableVariableRowProps extends VariableProps {
-  onInsertBelow: (index: number) => void;
-  setNodeRef?: (node: HTMLElement | null) => void;
+  sortableId: string;
   style?: React.CSSProperties;
   handleProps?: SortableHandleProps;
+  onClose: () => void;
+  onInsertBelow: (index: number) => void;
+  setNodeRef?: (node: HTMLElement | null) => void;
 }
 
 export const DeleteButton: React.FC<{ variable: ContextVariable | Variable }> = ({ variable }) => {
@@ -125,7 +123,7 @@ export const DescriptionField: React.FC<{ variable: Variable | ContextVariable }
       value={description}
       onChange={handleChange}
       variant='standard'
-      InputProps={{ 
+      InputProps={{
         disableUnderline: true,
       }}
       onClear={handleClear}
@@ -199,8 +197,8 @@ export const DefaultValueField: React.FC<{ variable: ContextVariable }> = ({ var
       value={defaultValue}
       onChange={handleChange}
       variant='standard'
-      InputProps={{ 
-        disableUnderline: true, 
+      InputProps={{
+        disableUnderline: true,
       }}
       onClear={handleClear}
       fullWidth

--- a/frontend/dialob-composer-material/src/dialob/actions.ts
+++ b/frontend/dialob-composer-material/src/dialob/actions.ts
@@ -27,7 +27,7 @@ export type ComposerAction =
 
   | { type: 'createValueSet', itemId: string | null, entries?: ValueSetEntry[] }
   | { type: 'setValueSetEntries', valueSetId: string, entries: ValueSetEntry[] }
-  | { type: 'addValueSetEntry', valueSetId: string, entry?: ValueSetEntry }
+  | { type: 'addValueSetEntry', valueSetId: string, entry?: ValueSetEntry, insertAfterIndex?: number }
   | { type: 'updateValueSetEntry', valueSetId: string, index: number, entry: ValueSetEntry }
   | { type: 'updateValueSetEntryLabel', valueSetId: string, index: number, text: string | null | undefined, language: string }
   | { type: 'deleteValueSetentry', valueSetId: string, index: number }
@@ -40,7 +40,7 @@ export type ComposerAction =
   | { type: 'setMetadataValue', attr: string, value: any }
   | { type: 'setContextValue', name: string, value: string }
 
-  | { type: 'createVariable', context: boolean }
+  | { type: 'createVariable', context: boolean, insertAfterIndex?: number }
   | { type: 'createScopedExpressionVariable', rowgroupId: string, callbacks?: ComposerCallbacks }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | { type: 'updateContextVariable', variableId: string, contextType?: ContextVariableType | string, defaultValue?: any }
@@ -48,7 +48,7 @@ export type ComposerAction =
   | { type: 'updateVariablePublishing', variableId: string, published: boolean }
   | { type: 'updateVariableDescription', variableId: string, description: string | undefined }
   | { type: 'deleteVariable', variableId: string }
-  | { type: 'moveVariable', origin: ContextVariable | Variable, destination: ContextVariable | Variable }
+  | { type: 'moveVariable', name: string, toFilteredIndex: number, context: boolean }
 
   | { type: 'addLanguage', language: string, copyFrom?: string }
   | { type: 'deleteLanguage', language: string }

--- a/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
+++ b/frontend/dialob-composer-material/src/dialob/react/useComposer.ts
@@ -73,8 +73,8 @@ export const useComposer = () => {
     dispatch({ type: 'setValueSetEntries', valueSetId, entries });
   }
 
-  const addValueSetEntry = (valueSetId: string, entry?: ValueSetEntry) => {
-    dispatch({ type: 'addValueSetEntry', valueSetId, entry });
+  const addValueSetEntry = (valueSetId: string, entry?: ValueSetEntry, insertAfterIndex?: number) => {
+    dispatch({ type: 'addValueSetEntry', valueSetId, entry, insertAfterIndex });
   }
 
   const updateValueSetEntry = (valueSetId: string, index: number, entry: ValueSetEntry) => {
@@ -114,8 +114,8 @@ export const useComposer = () => {
     dispatch({ type: 'setContextValue', name, value });
   }
 
-  const createVariable = (context: boolean) => {
-    dispatch({ type: 'createVariable', context });
+  const createVariable = (context: boolean, insertAfterIndex?: number) => {
+    dispatch({ type: 'createVariable', context, insertAfterIndex });
   }
 
   const createScopedExpressionVariable = (rowgroupId: string, callbacks?: ComposerCallbacks) => {
@@ -143,8 +143,8 @@ export const useComposer = () => {
     dispatch({ type: 'deleteVariable', variableId });
   }
 
-  const moveVariable = (origin: ContextVariable | Variable, destination: ContextVariable | Variable) => {
-    dispatch({ type: 'moveVariable', origin, destination });
+  const moveVariable = (name: string, toFilteredIndex: number, context: boolean) => {
+    dispatch({ type: 'moveVariable', name, toFilteredIndex, context });
   }
 
   const addLanguage = (language: string, copyFrom?: string) => {

--- a/frontend/dialob-composer-material/src/dialob/reducer.ts
+++ b/frontend/dialob-composer-material/src/dialob/reducer.ts
@@ -7,6 +7,8 @@ import {
   DialobItem
 } from '../types';
 import { isContextVariable } from '../utils/ItemUtils';
+import { shiftValueSetTranslationIndices, syncValueSetTranslationIndices } from '../utils/ValueSetUtils';
+import { reorderVariableSubset } from '../utils/VariableUtils';
 import { cleanLocalizedString, cleanString } from '../utils/StringUtils';
 import { SavingState } from '../dialogs/contexts/saving/SavingContext';
 import { FlattenedItem } from '../components/tree/types';
@@ -380,13 +382,19 @@ const setValueSetEntries = (state: ComposerState, valueSetId: string, entries: V
   }
 }
 
-const addValueSetEntry = (state: ComposerState, valueSetId: string, entry?: ValueSetEntry): void => {
+const addValueSetEntry = (state: ComposerState, valueSetId: string, entry?: ValueSetEntry, insertAfterIndex?: number): void => {
   if (state.valueSets) {
     const vsIdx = state.valueSets.findIndex(vs => vs.id === valueSetId);
     if (vsIdx > -1) {
       const cleanedEntry: ValueSetEntry = entry ? { ...entry, label: cleanLocalizedString(entry.label) } : { id: '', label: {} };
       if (state.valueSets[vsIdx].entries !== undefined) {
-        state.valueSets[vsIdx].entries!.push(cleanedEntry);
+        if (insertAfterIndex !== undefined && insertAfterIndex >= -1) {
+          const insertIndex = insertAfterIndex + 1;
+          shiftValueSetTranslationIndices(state.metadata.composer?.aiTranslations, valueSetId, insertIndex, 1);
+          state.valueSets[vsIdx].entries!.splice(insertIndex, 0, cleanedEntry);
+        } else {
+          state.valueSets[vsIdx].entries!.push(cleanedEntry);
+        }
       } else {
         state.valueSets[vsIdx].entries = [cleanedEntry];
       }
@@ -451,8 +459,10 @@ const moveValueSetEntry = (state: ComposerState, valueSetId: string, from: numbe
   if (state.valueSets) {
     const vsIdx = state.valueSets.findIndex(vs => vs.id === valueSetId);
     if (vsIdx > -1 && state.valueSets[vsIdx].entries !== undefined) {
-      const newIndex = to > state.valueSets[vsIdx].entries!.length ? state.valueSets[vsIdx].entries!.length - 1 : to;
-      state.valueSets[vsIdx].entries!.splice(newIndex, 0, state.valueSets[vsIdx].entries!.splice(from, 1)[0]);
+      const entries = state.valueSets[vsIdx].entries!;
+      const newIndex = to > entries.length ? entries.length - 1 : to;
+      entries.splice(newIndex, 0, entries.splice(from, 1)[0]);
+      syncValueSetTranslationIndices(state.metadata.composer?.aiTranslations, valueSetId, entries);
     }
   }
 }
@@ -510,7 +520,7 @@ const setContextValue = (state: ComposerState, name: string, value: string): voi
   }
 }
 
-const createVariable = (state: ComposerState, context: boolean): void => {
+const createVariable = (state: ComposerState, context: boolean, insertAfterIndex?: number): void => {
   const variableId = generateItemIdWithPrefix(state, context ? 'context' : 'var');
 
   const variable: ContextVariable | Variable = context ? {
@@ -524,6 +534,8 @@ const createVariable = (state: ComposerState, context: boolean): void => {
 
   if (!Array.isArray(state.variables)) {
     state.variables = [variable];
+  } else if (insertAfterIndex !== undefined && insertAfterIndex >= -1) {
+    state.variables.splice(insertAfterIndex + 1, 0, variable);
   } else {
     state.variables.push(variable);
   }
@@ -625,11 +637,9 @@ const updateVariableDescription = (state: ComposerState, variableId: string, des
   }
 }
 
-const moveVariable = (state: ComposerState, origin: ContextVariable | Variable, destination: ContextVariable | Variable): void => {
-  const originIdx = state.variables?.findIndex(v => v.name === origin.name);
-  const destinationIdx = state.variables?.findIndex(v => v.name === destination.name);
-  if (originIdx !== undefined && destinationIdx !== undefined && originIdx > -1 && destinationIdx > -1 && state.variables) {
-    [state.variables[originIdx], state.variables[destinationIdx]] = [state.variables[destinationIdx], state.variables[originIdx]];
+const moveVariable = (state: ComposerState, name: string, toFilteredIndex: number, context: boolean): void => {
+  if (state.variables) {
+    reorderVariableSubset(state.variables, name, toFilteredIndex, context);
   }
 }
 
@@ -750,7 +760,7 @@ const applyListChanges = (state: ComposerState, newState: SavingState): void => 
 const applyVariableChanges = (state: ComposerState, newState: SavingState): void => {
   // Apply changes from the SavingContext - used to apply changes made in the VariablesDialog
   state.variables = newState.variables;
-  
+
   // Also apply any modified items (e.g., rowgroup items arrays that were updated)
   if (newState.items) {
     Object.keys(newState.items).forEach(itemId => {
@@ -786,7 +796,7 @@ const applyTranslations = (state: ComposerState, translations: TranslationResult
 
   translations.forEach(translation => {
     const parts = translation.id.split(':');
-    
+
     if (parts[0] === 'i') {
       // Item translation: i:itemId:type or i:itemId:v:index
       const itemId = parts[1];
@@ -844,7 +854,7 @@ const removeAITranslation = (state: ComposerState, entryId: string, targetLangua
   if (!state.metadata.composer?.aiTranslations) {
     return;
   }
-  
+
   state.metadata.composer.aiTranslations = state.metadata.composer.aiTranslations.filter(
     t => !(t.entryId === entryId && t.targetLanguage === targetLanguage)
   );
@@ -888,7 +898,7 @@ export const formReducer = (state: ComposerState, action: ComposerAction, callba
     } else if (action.type === 'setValueSetEntries') {
       setValueSetEntries(state, action.valueSetId, action.entries);
     } else if (action.type === 'addValueSetEntry') {
-      addValueSetEntry(state, action.valueSetId, action.entry);
+      addValueSetEntry(state, action.valueSetId, action.entry, action.insertAfterIndex);
     } else if (action.type === 'updateValueSetEntry') {
       updateValueSetEntry(state, action.valueSetId, action.index, action.entry);
     } else if (action.type === 'updateValueSetEntryLabel') {
@@ -908,7 +918,7 @@ export const formReducer = (state: ComposerState, action: ComposerAction, callba
     } else if (action.type === 'setContextValue') {
       setContextValue(state, action.name, action.value);
     } else if (action.type === 'createVariable') {
-      createVariable(state, action.context);
+      createVariable(state, action.context, action.insertAfterIndex);
     } else if (action.type === 'createScopedExpressionVariable') {
       createScopedExpressionVariable(state, action.rowgroupId, action.callbacks ?? callbacks);
     } else if (action.type === 'updateContextVariable') {
@@ -922,7 +932,7 @@ export const formReducer = (state: ComposerState, action: ComposerAction, callba
     } else if (action.type === 'deleteVariable') {
       deleteVariable(state, action.variableId);
     } else if (action.type === 'moveVariable') {
-      moveVariable(state, action.origin, action.destination);
+      moveVariable(state, action.name, action.toFilteredIndex, action.context);
     } else if (action.type === 'addLanguage') {
       addLanguage(state, action.language, action.copyFrom);
     } else if (action.type === 'deleteLanguage') {

--- a/frontend/dialob-composer-material/src/dialob/test/reducer.test.ts
+++ b/frontend/dialob-composer-material/src/dialob/test/reducer.test.ts
@@ -640,6 +640,27 @@ test('Add valueset entry: empty', () => {
 });
 
 
+test('Add valueset entry after index', () => {
+  const action: ComposerAction = {
+    type: 'addValueSetEntry',
+    valueSetId: 'vs2',
+    insertAfterIndex: 1,
+    entry: {
+      id: 'inserted', label: { 'en': 'Inserted' }
+    }
+  };
+  const newState = formReducer(testForm, action);
+  expect(newState.valueSets).toBeDefined();
+  if (newState.valueSets) {
+    const vsIndex = newState.valueSets.findIndex(vs => vs.id === 'vs2');
+    expect(vsIndex).toBeGreaterThan(-1);
+    expect(newState.valueSets[vsIndex].entries).toBeDefined();
+    expect(newState.valueSets[vsIndex].entries!.length).toEqual(7);
+    expect(newState.valueSets[vsIndex].entries![2]).toStrictEqual({ id: 'inserted', label: { 'en': 'Inserted' } });
+    expect(newState.valueSets[vsIndex].entries![3].id).toEqual('prevention3');
+  }
+});
+
 test('Add valueset entry: filled', () => {
   const action: ComposerAction = {
     type: 'addValueSetEntry',
@@ -885,6 +906,21 @@ test('Create context variable', () => {
   }
 });
 
+test('Create context variable after index', () => {
+  const prefilledCompanyNameIndex = testForm.variables!.findIndex(v => v.name === 'prefilledCompanyName');
+  const action: ComposerAction = {
+    type: 'createVariable',
+    context: true,
+    insertAfterIndex: prefilledCompanyNameIndex
+  };
+  const newState = formReducer(testForm, action);
+  expect(newState.variables).toBeDefined();
+  if (newState.variables) {
+    expect(newState.variables[prefilledCompanyNameIndex + 1].name).toEqual('context1');
+    expect(newState.variables[prefilledCompanyNameIndex].name).toEqual('prefilledCompanyName');
+  }
+});
+
 test('Create expression variable', () => {
   const action: ComposerAction = {
     type: 'createVariable',
@@ -1003,28 +1039,40 @@ test('Delete variable', () => {
   }
 });
 
-test('Move variable (swap)', () => {
+test('Move variable within context subset', () => {
   expect(testForm.variables).toBeDefined();
-  const originIndex = testForm.variables.findIndex(v => v.name === 'prefilledCompanyName');
-  expect(originIndex).toBeGreaterThan(-1);
-  const origin = testForm.variables[originIndex];
-  const destinationIndex = testForm.variables.findIndex(v => v.name === 'prefilledCompanyID');
-  expect(destinationIndex).toBeGreaterThan(-1);
-  const destination = testForm.variables[destinationIndex];
   const action: ComposerAction = {
     type: 'moveVariable',
-    origin: origin,
-    destination: destination
-  }
+    name: 'companyExists',
+    toFilteredIndex: 0,
+    context: true
+  };
   const newState = formReducer(testForm, action);
   expect(newState.variables).toBeDefined();
   if (newState.variables) {
-    const nameIndex = newState.variables.findIndex(v => v.name === 'prefilledCompanyName');
-    expect(nameIndex).toBeGreaterThan(-1);
-    expect(nameIndex).toBe(destinationIndex);
-    const idIndex = newState.variables.findIndex(v => v.name === 'prefilledCompanyID');
-    expect(idIndex).toBeGreaterThan(-1);
-    expect(idIndex).toBe(originIndex);
+    const contextVars = newState.variables.filter(v => 'context' in v && v.context);
+    expect(contextVars[0].name).toEqual('companyExists');
+    expect(contextVars[1].name).toEqual('prefilledCompanyID');
+    expect(contextVars[2].name).toEqual('prefilledCompanyName');
+    expect(newState.variables.findIndex(v => v.name === 'companyMainBL')).toBe(0);
+  }
+});
+
+test('Move variable (swap)', () => {
+  expect(testForm.variables).toBeDefined();
+  const action: ComposerAction = {
+    type: 'moveVariable',
+    name: 'prefilledCompanyName',
+    toFilteredIndex: 0,
+    context: true
+  };
+  const newState = formReducer(testForm, action);
+  expect(newState.variables).toBeDefined();
+  if (newState.variables) {
+    const contextVars = newState.variables.filter(v => 'context' in v && v.context);
+    expect(contextVars[0].name).toEqual('prefilledCompanyName');
+    expect(contextVars[1].name).toEqual('prefilledCompanyID');
+    expect(contextVars[2].name).toEqual('companyExists');
   }
 });
 

--- a/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
+++ b/frontend/dialob-composer-material/src/dialogs/GlobalListsDialog.tsx
@@ -14,6 +14,7 @@ import { useEditor } from '../editor';
 import { getErrorSeverity, getItemErrorColor } from '../utils/ErrorUtils';
 import { scrollToItem, scrollToChoiceItem } from '../utils/ScrollUtils';
 import { downloadValueSet } from '../utils/ParseUtils';
+import { createDefaultValueSetEntry } from '../utils/ValueSetUtils';
 import { ErrorMessage } from '../components/ErrorComponents';
 import { BoldedMessage } from '../intl/BoldedMessage';
 import { useDocs } from '../utils/DocsUtils';
@@ -37,12 +38,12 @@ const SaveButton: React.FC = () => {
 
   const hasChanges = React.useMemo(() => {
     return (savingState.valueSets && (JSON.stringify(savingState.valueSets) !== JSON.stringify(form.valueSets))) ||
-      (savingState.composerMetadata?.globalValueSets && 
+      (savingState.composerMetadata?.globalValueSets &&
         (JSON.stringify(savingState.composerMetadata?.globalValueSets) !== JSON.stringify(form.metadata.composer?.globalValueSets))) ||
-      (savingState.composerMetadata?.aiTranslations && 
+      (savingState.composerMetadata?.aiTranslations &&
         (JSON.stringify(savingState.composerMetadata?.aiTranslations) !== JSON.stringify(form.metadata.composer?.aiTranslations)));
   }, [savingState, form.valueSets, form.metadata.composer?.globalValueSets, form.metadata.composer?.aiTranslations]);
-  
+
   const handleSave = () => {
     if (savingState.valueSets && savingState.composerMetadata?.globalValueSets) {
       applyListChanges(savingState);
@@ -79,7 +80,7 @@ const GlobalListsDialogContent: React.FC = () => {
   const lastActiveList = React.useRef<string | undefined>(undefined);
   const users = currentValueSet && Object.values(form.data).filter(i => i.valueSetId === currentValueSet?.id);
   const itemErrors = editor.errors?.filter(e => e.itemId === currentValueSet?.id);
-  
+
   const sourceLanguage = editor.activeFormLanguage;
   const targetLanguages = formLanguages?.filter(lang => lang !== sourceLanguage) || [];
   const hasTranslatableContent = useHasTranslatableContent(currentValueSet, sourceLanguage, targetLanguages);
@@ -106,19 +107,19 @@ const GlobalListsDialogContent: React.FC = () => {
       setGlobalValueSets(mappedGvs);
     }
   }, [savingState, dialogOpen]);
-  
+
   // Set currentValueSet only when dialog opens or when activeList changes
   React.useEffect(() => {
     // Check if activeList has changed or this is first render
     const activeListChanged = lastActiveList.current !== editor.activeList;
-    
+
     if (dialogOpen && activeListChanged && savingState.valueSets && savingState.composerMetadata?.globalValueSets) {
       const mappedGvs = getMappedGvs();
-      
+
       if (mappedGvs && mappedGvs.length > 0) {
         if (editor.activeList && editor.activeList !== 'global') {
           const activeList = savingState.valueSets.find(vs => vs.id === editor.activeList);
-          
+
           if (activeList) {
             setCurrentValueSet(activeList);
             lastActiveList.current = editor.activeList;
@@ -130,7 +131,7 @@ const GlobalListsDialogContent: React.FC = () => {
         lastActiveList.current = editor.activeList;
       }
     }
-    
+
     // Reset tracking when dialog closes
     if (!dialogOpen) {
       lastActiveList.current = undefined;
@@ -171,23 +172,11 @@ const GlobalListsDialogContent: React.FC = () => {
 
   const addEntry = () => {
     if (currentValueSet) {
-      if (!currentValueSet.entries) {
-        const newEntry = {
-          id: 'choice1',
-          label: {}
-        }
-        addValueSetEntry(currentValueSet.id, newEntry);
-        setCurrentValueSet({ ...currentValueSet, entries: [newEntry] });
-        scrollToChoiceItem();
-      } else {
-        const newEntry = {
-          id: 'choice' + (currentValueSet.entries?.length + 1),
-          label: {},
-        };
-        addValueSetEntry(currentValueSet.id, newEntry);
-        setCurrentValueSet({ ...currentValueSet, entries: [...currentValueSet.entries, newEntry] });
-        scrollToChoiceItem();
-      }
+      const newEntry = createDefaultValueSetEntry(currentValueSet.entries);
+      addValueSetEntry(currentValueSet.id, newEntry);
+      const newEntries = currentValueSet.entries ? [...currentValueSet.entries, newEntry] : [newEntry];
+      setCurrentValueSet({ ...currentValueSet, entries: newEntries });
+      scrollToChoiceItem();
     }
   }
 
@@ -234,7 +223,7 @@ const GlobalListsDialogContent: React.FC = () => {
     <>
       <UploadValuesetDialog open={uploadDialogOpen} onClose={() => setUploadDialogOpen(false)}
         currentValueSet={currentValueSet} setCurrentValueSet={setCurrentValueSet} />
-      
+
       <TranslateChoicesConfirmDialog
         open={translateDialogOpen}
         onConfirm={handleTranslateAllChoices}

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingAction.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/SavingAction.ts
@@ -24,7 +24,7 @@ export type SavingAction =
 
   | { type: 'createValueSet', itemId: string | null, entries?: ValueSetEntry[] }
   | { type: 'setValueSetEntries', valueSetId: string, entries: ValueSetEntry[] }
-  | { type: 'addValueSetEntry', valueSetId: string, entry?: ValueSetEntry }
+  | { type: 'addValueSetEntry', valueSetId: string, entry?: ValueSetEntry, insertAfterIndex?: number }
   | { type: 'updateValueSetEntry', valueSetId: string, index: number, entry: ValueSetEntry }
   | { type: 'updateValueSetEntryLabel', valueSetId: string, index: number, text: string | null | undefined, language: string }
   | { type: 'deleteValueSetentry', valueSetId: string, index: number }
@@ -33,14 +33,14 @@ export type SavingAction =
   | { type: 'deleteLocalValueSet', valueSetId: string }
   | { type: 'deleteGlobalValueSet', valueSetId: string }
 
-  | { type: 'createVariable', context: boolean }
+  | { type: 'createVariable', context: boolean, insertAfterIndex?: number }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   | { type: 'updateContextVariable', variableId: string, contextType?: ContextVariableType | string, defaultValue?: any }
   | { type: 'updateExpressionVariable', variableId: string, expression: string | undefined }
   | { type: 'updateVariablePublishing', variableId: string, published: boolean }
   | { type: 'updateVariableDescription', variableId: string, description: string | undefined }
   | { type: 'deleteVariable', variableId: string }
-  | { type: 'moveVariable', origin: ContextVariable | Variable, destination: ContextVariable | Variable }
+  | { type: 'moveVariable', name: string, toFilteredIndex: number, context: boolean }
   | { type: 'changeVariableId', variables: (ContextVariable | Variable)[] }
   | { type: 'updateVariableName', currentName: string, originalName: string, to: string }
   | { type: 'clearPendingRenames' }

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/reducer.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/reducer.ts
@@ -4,6 +4,8 @@ import { cleanLocalizedString, cleanString } from "../../../utils/StringUtils";
 import { SavingAction } from "./SavingAction";
 import { SavingState } from "./SavingContext";
 import { isContextVariable } from "../../../utils/ItemUtils";
+import { shiftValueSetTranslationIndices, syncValueSetTranslationIndices } from "../../../utils/ValueSetUtils";
+import { reorderVariableSubset } from "../../../utils/VariableUtils";
 import { TranslationResult } from "../../../backend/types";
 
 
@@ -258,13 +260,19 @@ const setValueSetEntries = (state: SavingState, valueSetId: string, entries: Val
   }
 }
 
-const addValueSetEntry = (state: SavingState, valueSetId: string, entry?: ValueSetEntry): void => {
+const addValueSetEntry = (state: SavingState, valueSetId: string, entry?: ValueSetEntry, insertAfterIndex?: number): void => {
   if (state.valueSets) {
     const vsIdx = state.valueSets.findIndex(vs => vs.id === valueSetId);
     if (vsIdx > -1) {
       const cleanedEntry: ValueSetEntry = entry ? { ...entry, label: cleanLocalizedString(entry.label) } : { id: '', label: {} };
       if (state.valueSets[vsIdx].entries !== undefined) {
-        state.valueSets[vsIdx].entries!.push(cleanedEntry);
+        if (insertAfterIndex !== undefined && insertAfterIndex >= -1) {
+          const insertIndex = insertAfterIndex + 1;
+          shiftValueSetTranslationIndices(state.composerMetadata?.aiTranslations, valueSetId, insertIndex, 1);
+          state.valueSets[vsIdx].entries!.splice(insertIndex, 0, cleanedEntry);
+        } else {
+          state.valueSets[vsIdx].entries!.push(cleanedEntry);
+        }
       } else {
         state.valueSets[vsIdx].entries = [cleanedEntry];
       }
@@ -325,8 +333,10 @@ const moveValueSetEntry = (state: SavingState, valueSetId: string, from: number,
   if (state.valueSets) {
     const vsIdx = state.valueSets.findIndex(vs => vs.id === valueSetId);
     if (vsIdx > -1 && state.valueSets[vsIdx].entries !== undefined) {
-      const newIndex = to > state.valueSets[vsIdx].entries!.length ? state.valueSets[vsIdx].entries!.length - 1 : to;
-      state.valueSets[vsIdx].entries!.splice(newIndex, 0, state.valueSets[vsIdx].entries!.splice(from, 1)[0]);
+      const entries = state.valueSets[vsIdx].entries!;
+      const newIndex = to > entries.length ? entries.length - 1 : to;
+      entries.splice(newIndex, 0, entries.splice(from, 1)[0]);
+      syncValueSetTranslationIndices(state.composerMetadata?.aiTranslations, valueSetId, entries);
     }
   }
 }
@@ -367,7 +377,7 @@ const deleteGlobalValueSet = (state: SavingState, valueSetId: string): void => {
   }
 }
 
-const createVariable = (state: SavingState, context: boolean): void => {
+const createVariable = (state: SavingState, context: boolean, insertAfterIndex?: number): void => {
   const variableId = generateItemIdWithPrefix(state, context ? 'context' : 'var');
 
   const variable: ContextVariable | Variable = context ? {
@@ -381,6 +391,8 @@ const createVariable = (state: SavingState, context: boolean): void => {
 
   if (!Array.isArray(state.variables)) {
     state.variables = [variable];
+  } else if (insertAfterIndex !== undefined && insertAfterIndex >= -1) {
+    state.variables.splice(insertAfterIndex + 1, 0, variable);
   } else {
     state.variables.push(variable);
   }
@@ -437,11 +449,9 @@ const updateVariableDescription = (state: SavingState, variableId: string, descr
   }
 }
 
-const moveVariable = (state: SavingState, origin: ContextVariable | Variable, destination: ContextVariable | Variable): void => {
-  const originIdx = state.variables?.findIndex(v => v.name === origin.name);
-  const destinationIdx = state.variables?.findIndex(v => v.name === destination.name);
-  if (originIdx !== undefined && destinationIdx !== undefined && originIdx > -1 && destinationIdx > -1 && state.variables) {
-    [state.variables[originIdx], state.variables[destinationIdx]] = [state.variables[destinationIdx], state.variables[originIdx]];
+const moveVariable = (state: SavingState, name: string, toFilteredIndex: number, context: boolean): void => {
+  if (state.variables) {
+    reorderVariableSubset(state.variables, name, toFilteredIndex, context);
   }
 }
 
@@ -496,18 +506,18 @@ const changeVariableId = (state: SavingState, variables: (ContextVariable | Vari
     // Build a map of old variable names to new variable names
     const oldNames = new Set(state.variables.map(v => v.name));
     const newNames = new Set(variables.map(v => v.name));
-    
+
     // Find names that exist in old but not in new (removed/renamed)
     const removedNames = Array.from(oldNames).filter(name => !newNames.has(name));
-    
+
     // Find names that exist in new but not in old (added/renamed to)
     const addedNames = Array.from(newNames).filter(name => !oldNames.has(name));
-    
+
     // If we have exactly one removed and one added, it's a rename
     if (removedNames.length === 1 && addedNames.length === 1) {
       const oldName = removedNames[0];
       const newName = addedNames[0];
-      
+
       // Update any rowgroup that contains the old name
       Object.values(state.items).forEach(item => {
         if (item.type === 'rowgroup' && item.items?.includes(oldName)) {
@@ -519,7 +529,7 @@ const changeVariableId = (state: SavingState, variables: (ContextVariable | Vari
       });
     }
   }
-  
+
   if (state.variables) {
     state.variables = variables;
   }
@@ -546,7 +556,7 @@ const applyTranslations = (state: SavingState, translations: TranslationResult[]
 
   translations.forEach(translation => {
     const parts = translation.id.split(':');
-    
+
     if (parts[0] === 'i' && state.item) {
       // Item translations: labels, descriptions, validations
       const itemId = parts[1];
@@ -579,7 +589,7 @@ const applyTranslations = (state: SavingState, translations: TranslationResult[]
       const valueSetId = parts[1];
       const entryIndex = parseInt(parts[2], 10);
       const valueSet = state.valueSets.find(vs => vs.id === valueSetId);
-      
+
       if (valueSet?.entries?.[entryIndex]) {
         valueSet.entries[entryIndex].label = {
           ...(valueSet.entries[entryIndex].label || {}),
@@ -606,12 +616,12 @@ const addAITranslation = (state: SavingState, entryId: string, sourceLanguage: s
   if (!state.composerMetadata.aiTranslations) {
     state.composerMetadata.aiTranslations = [];
   }
-  
+
   // Remove existing translation for this entry+target language if any
   state.composerMetadata.aiTranslations = state.composerMetadata.aiTranslations.filter(
     t => !(t.entryId === entryId && t.targetLanguage === targetLanguage)
   );
-  
+
   // Add new translation metadata
   state.composerMetadata.aiTranslations.push({
     entryId,
@@ -625,7 +635,7 @@ const removeAITranslation = (state: SavingState, entryId: string, targetLanguage
   if (!state.composerMetadata?.aiTranslations) {
     return;
   }
-  
+
   state.composerMetadata.aiTranslations = state.composerMetadata.aiTranslations.filter(
     t => !(t.entryId === entryId && t.targetLanguage === targetLanguage)
   );
@@ -660,7 +670,7 @@ export const itemReducer = (state: SavingState, action: SavingAction): SavingSta
     } else if (action.type === 'setValueSetEntries') {
       setValueSetEntries(state, action.valueSetId, action.entries);
     } else if (action.type === 'addValueSetEntry') {
-      addValueSetEntry(state, action.valueSetId, action.entry);
+      addValueSetEntry(state, action.valueSetId, action.entry, action.insertAfterIndex);
     } else if (action.type === 'updateValueSetEntry') {
       updateValueSetEntry(state, action.valueSetId, action.index, action.entry);
     } else if (action.type === 'updateValueSetEntryLabel') {
@@ -676,19 +686,19 @@ export const itemReducer = (state: SavingState, action: SavingAction): SavingSta
     } else if (action.type === 'deleteGlobalValueSet') {
       deleteGlobalValueSet(state, action.valueSetId);
     } else if (action.type === 'createVariable') {
-      createVariable(state, action.context);
+      createVariable(state, action.context, action.insertAfterIndex);
     } else if (action.type === 'updateContextVariable') {
       updateContextVariable(state, action.variableId, action.contextType, action.defaultValue);
     } else if (action.type === 'updateExpressionVariable') {
       updateExpressionVariable(state, action.variableId, action.expression);
     } else if (action.type === 'updateVariablePublishing') {
       updateVariablePublishing(state, action.variableId, action.published);
-    } else if (action.type === 'updateVariableDescription') { 
+    } else if (action.type === 'updateVariableDescription') {
       updateVariableDescription(state, action.variableId, action.description);
     } else if (action.type === 'deleteVariable') {
       deleteVariable(state, action.variableId);
     } else if (action.type === 'moveVariable') {
-      moveVariable(state, action.origin, action.destination);
+      moveVariable(state, action.name, action.toFilteredIndex, action.context);
     } else if (action.type === 'changeVariableId') {
       changeVariableId(state, action.variables);
     } else if (action.type === 'updateVariableName') {

--- a/frontend/dialob-composer-material/src/dialogs/contexts/saving/useSave.ts
+++ b/frontend/dialob-composer-material/src/dialogs/contexts/saving/useSave.ts
@@ -56,8 +56,8 @@ export const useSave = () => {
     dispatch({ type: 'setValueSetEntries', valueSetId, entries });
   }
 
-  const addValueSetEntry = (valueSetId: string, entry?: ValueSetEntry) => {
-    dispatch({ type: 'addValueSetEntry', valueSetId, entry });
+  const addValueSetEntry = (valueSetId: string, entry?: ValueSetEntry, insertAfterIndex?: number) => {
+    dispatch({ type: 'addValueSetEntry', valueSetId, entry, insertAfterIndex });
   }
 
   const updateValueSetEntry = (valueSetId: string, index: number, entry: ValueSetEntry) => {
@@ -88,8 +88,8 @@ export const useSave = () => {
     dispatch({ type: 'deleteGlobalValueSet', valueSetId });
   }
 
-  const createVariable = (context: boolean) => {
-    dispatch({ type: 'createVariable', context });
+  const createVariable = (context: boolean, insertAfterIndex?: number) => {
+    dispatch({ type: 'createVariable', context, insertAfterIndex });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -113,8 +113,8 @@ export const useSave = () => {
     dispatch({ type: 'deleteVariable', variableId });
   }
 
-  const moveVariable = (origin: ContextVariable | Variable, destination: ContextVariable | Variable) => {
-    dispatch({ type: 'moveVariable', origin, destination });
+  const moveVariable = (name: string, toFilteredIndex: number, context: boolean) => {
+    dispatch({ type: 'moveVariable', name, toFilteredIndex, context });
   }
 
   const changeVariableId = (variables: (ContextVariable | Variable)[]) => {

--- a/frontend/dialob-composer-material/src/utils/ScrollUtils.ts
+++ b/frontend/dialob-composer-material/src/utils/ScrollUtils.ts
@@ -44,7 +44,7 @@ export const scrollToItem = (itemId: string, items: DialobItem[], activePage: Di
 export const scrollToTreeItem = (itemId: string) => {
   const tree = document.querySelector('#tree-scroll-container') as HTMLElement;
   const item = document.querySelector(`#tree-item-${itemId}`) as HTMLElement;
-  
+
   if (tree && item) {
     setTimeout(() => {
       const itemTop = item.offsetTop - tree.offsetTop;
@@ -72,7 +72,7 @@ export const scrollToAddedItem = (item: DialobItem) => {
 const scrollToDialogRow = (rowSelector: string, index?: number) => {
   const dialogContent = document.querySelector('.MuiDialogContent-root');
   if (dialogContent) {
-    // Double rAF + small delay lets complex table layouts finish rendering the new row first.
+    // Double requestAnimationFrame + small delay lets complex table layouts finish rendering the new row first
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         setTimeout(() => {

--- a/frontend/dialob-composer-material/src/utils/ScrollUtils.ts
+++ b/frontend/dialob-composer-material/src/utils/ScrollUtils.ts
@@ -67,20 +67,21 @@ export const scrollToAddedItem = (item: DialobItem) => {
   }), 500);
 }
 
-export const scrollToChoiceItem = () => {
+// Scrolls a table row (matched by data-attribute selector) into view inside the open dialog.
+// When index is omitted or out of range, the last row is targeted (used after appending).
+const scrollToDialogRow = (rowSelector: string, index?: number) => {
   const dialogContent = document.querySelector('.MuiDialogContent-root');
   if (dialogContent) {
-    // Use requestAnimationFrame to ensure DOM updates are complete,
-    // with a small delay to allow complex table layouts to finish rendering
+    // Double rAF + small delay lets complex table layouts finish rendering the new row first.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         setTimeout(() => {
-          // Find all choice item tables and get the last one
-          const choiceTables = dialogContent.querySelectorAll('table table');
-          const lastChoiceItem = choiceTables[choiceTables.length - 1];
+          const rows = dialogContent.querySelectorAll(rowSelector);
+          const target = index !== undefined && index >= 0 && index < rows.length
+            ? rows[index]
+            : rows[rows.length - 1];
 
-          // Scroll the last item into view
-          lastChoiceItem.scrollIntoView({
+          target?.scrollIntoView({
             behavior: 'smooth',
             block: 'nearest',
             inline: 'nearest'
@@ -90,3 +91,7 @@ export const scrollToChoiceItem = () => {
     });
   }
 }
+
+export const scrollToChoiceItem = (index?: number) => scrollToDialogRow('[data-choice-item-row]', index);
+
+export const scrollToVariableRow = (index?: number) => scrollToDialogRow('[data-variable-row]', index);

--- a/frontend/dialob-composer-material/src/utils/ValueSetUtils.ts
+++ b/frontend/dialob-composer-material/src/utils/ValueSetUtils.ts
@@ -1,0 +1,71 @@
+import { ValueSetEntry, TranslationMetadata } from '../types';
+
+export const createDefaultValueSetEntry = (existingEntries?: ValueSetEntry[]): ValueSetEntry => {
+  if (!existingEntries || existingEntries.length === 0) {
+    return { id: 'choice1', label: {} };
+  }
+  return {
+    id: 'choice' + (existingEntries.length + 1),
+    label: {},
+  };
+};
+
+const getValueSetEntryIdPart = (entryId: string, valueSetId: string): string | undefined => {
+  const prefix = `v:${valueSetId}:`;
+  if (!entryId.startsWith(prefix)) {
+    return undefined;
+  }
+  const rest = entryId.slice(prefix.length);
+  const colonIdx = rest.indexOf(':');
+  if (colonIdx === -1) {
+    return undefined;
+  }
+  return rest.slice(colonIdx + 1);
+};
+
+export const shiftValueSetTranslationIndices = (
+  translations: TranslationMetadata[] | undefined,
+  valueSetId: string,
+  fromIndex: number,
+  delta: number
+): void => {
+  if (!translations || delta === 0) {
+    return;
+  }
+  const prefix = `v:${valueSetId}:`;
+  translations.forEach(t => {
+    if (t.entryId.startsWith(prefix)) {
+      const entryIdPart = getValueSetEntryIdPart(t.entryId, valueSetId);
+      if (entryIdPart === undefined) {
+        return;
+      }
+      const entryIndex = parseInt(t.entryId.slice(prefix.length).split(':')[0], 10);
+      if (entryIndex >= fromIndex) {
+        t.entryId = `v:${valueSetId}:${entryIndex + delta}:${entryIdPart}`;
+      }
+    }
+  });
+};
+
+export const syncValueSetTranslationIndices = (
+  translations: TranslationMetadata[] | undefined,
+  valueSetId: string,
+  entries: ValueSetEntry[]
+): void => {
+  if (!translations) {
+    return;
+  }
+  const prefix = `v:${valueSetId}:`;
+  translations.forEach(t => {
+    if (t.entryId.startsWith(prefix)) {
+      const entryIdPart = getValueSetEntryIdPart(t.entryId, valueSetId);
+      if (entryIdPart === undefined) {
+        return;
+      }
+      const newIndex = entries.findIndex(e => e.id === entryIdPart);
+      if (newIndex >= 0) {
+        t.entryId = `v:${valueSetId}:${newIndex}:${entryIdPart}`;
+      }
+    }
+  });
+};

--- a/frontend/dialob-composer-material/src/utils/VariableUtils.ts
+++ b/frontend/dialob-composer-material/src/utils/VariableUtils.ts
@@ -1,0 +1,33 @@
+import { ContextVariable, Variable } from '../types';
+import { isContextVariable } from './ItemUtils';
+
+const arrayMove = <T>(array: T[], from: number, to: number): T[] => {
+  const result = [...array];
+  const [item] = result.splice(from, 1);
+  result.splice(to, 0, item);
+  return result;
+};
+
+export const reorderVariableSubset = (
+  variables: (ContextVariable | Variable)[],
+  name: string,
+  toFilteredIndex: number,
+  context: boolean
+): void => {
+  const isTargetType = (variable: ContextVariable | Variable) =>
+    context ? isContextVariable(variable) : !isContextVariable(variable);
+
+  const subset = variables.filter(isTargetType);
+  const fromFilteredIndex = subset.findIndex(v => v.name === name);
+  if (fromFilteredIndex === -1 || fromFilteredIndex === toFilteredIndex) {
+    return;
+  }
+
+  const slots = variables
+    .map((variable, index) => isTargetType(variable) ? index : -1)
+    .filter(index => index >= 0);
+  const reordered = arrayMove(subset, fromFilteredIndex, toFilteredIndex);
+  slots.forEach((absIdx, i) => {
+    variables[absIdx] = reordered[i];
+  });
+};


### PR DESCRIPTION
## Summary

Improves choice item lists and variable tables in the Material composer with per-row **insert below** and **drag-to-reorder**, using the same `@dnd-kit` pattern as the left-hand tree menu.

## Changes

- Added an **insert below** button (`PostAdd`) on each row; the header add button still appends at the bottom
- Replaced up/down arrows with a **drag handle** for reordering
- Fixed table layout - removed improperly nested table rows and columns in choice and variable lists
- Fixed inline ID editing: rows use stable index-based keys so renaming no longer collapses the expanded editor
- Extended reducers so `addValueSetEntry` and `createVariable` accept optional `insertAfterIndex`, also `moveVariable` now supports drag reorder while keeping context/expression variables in the correct order
- Added sortable shared components and utilities for value set entry defaults, scrolling to items, and reordering variables 
- Earlier bug fixed as part of this: AI translation indexes are now also synced on insert/reorder to flag proper rows